### PR TITLE
Stream Selector Dropdown on Stream page for Multiple Camera Sources

### DIFF
--- a/src/Constants/rosConfig.ts
+++ b/src/Constants/rosConfig.ts
@@ -14,6 +14,12 @@ export interface StreamSource {
 
 export const STREAM_SOURCES: StreamSource[] = [
     {
+        id: 'ext-camera',
+        name: 'External USB Webcam',
+        topic: '/ext_camera/jpg',
+        messageType: 'sensor_msgs/msg/CompressedImage'
+    },
+    {
         id: 'realsense-rgb',
         name: 'Realsense RGB',
         topic: '/realsense/realsense2_camera/color/image_raw/compressed',

--- a/src/Pages/Stream.tsx
+++ b/src/Pages/Stream.tsx
@@ -1,14 +1,54 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
+import { Space, Typography, Select } from "antd";
 import { Page } from '../Components/Page';
-import { Space, Typography } from "antd";
 import { StreamPlayer } from '../Components/StreamPlayer';
 import { StreamMetrics } from '../Components/StreamMetrics';
+import type { StreamSource } from '../Constants/rosConfig';
+import { STREAM_SOURCES, DEFAULT_STREAM_SOURCE } from '../Constants/rosConfig';
 
 const Text = Typography;
+
+const SELECT_POPUP_STYLE = {
+    popup: {
+        root: {
+            backgroundColor: '#0d0d0d',
+            borderColor: '#333',
+        }
+    }
+};
+
+const WARNING_BADGE_STYLE: React.CSSProperties = {
+    color: '#ffa500',
+    fontFamily: 'monospace',
+    fontSize: 10,
+    padding: '2px 6px',
+    backgroundColor: '#1a1a1a',
+    border: '1px solid #ffa500',
+    borderRadius: 4
+};
 
 export const Stream: React.FC = () => {
     const [frameDelay, setFrameDelay] = useState<number>(0);
     const [fps, setFps] = useState<number>(0);
+    const [selectedStreamSource, setSelectedStreamSource] = useState<StreamSource>(DEFAULT_STREAM_SOURCE);
+    const [hasEmptyDataWarning, setHasEmptyDataWarning] = useState<boolean>(false);
+
+    const handleStreamSourceChange = (value: string) => {
+        const source = STREAM_SOURCES.find(s => s.id === value);
+        if (source) {
+            setSelectedStreamSource(source);
+            setHasEmptyDataWarning(false); // Reset warning when switching
+        }
+    };
+
+    const selectOptions = useMemo(() => 
+        STREAM_SOURCES.map(source => ({
+            value: source.id,
+            label: source.name
+        })), 
+        []
+    );
+
     const headerContent = (
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
             <div>
@@ -27,7 +67,26 @@ export const Stream: React.FC = () => {
                     </Text>
                 </Space>
             </div>
-            <StreamMetrics fps={fps} frameDelay={frameDelay} fontSize={12} />
+            <Space align="center" size="middle">
+                <Select
+                    size="small"
+                    value={selectedStreamSource.id}
+                    onChange={handleStreamSourceChange}
+                    style={{ width: 200 }}
+                    options={selectOptions}
+                    popupMatchSelectWidth={false}
+                    styles={SELECT_POPUP_STYLE}
+                />
+                <StreamMetrics fps={fps} frameDelay={frameDelay} fontSize={12} />
+                {hasEmptyDataWarning && (
+                    <span 
+                        style={WARNING_BADGE_STYLE}
+                        title="Topic is not publishing compressed image data. Check ROS configuration."
+                    >
+                        ⚠️ NO DATA
+                    </span>
+                )}
+            </Space>
         </div>
     );
 
@@ -38,7 +97,12 @@ export const Stream: React.FC = () => {
             contentStyle={{ padding: 12, position: 'relative' }}
             removeScrollbars={false}
         >
-            <StreamPlayer onFrameDelayChange={setFrameDelay} onFpsChange={setFps} />
+            <StreamPlayer 
+                onFrameDelayChange={setFrameDelay} 
+                onFpsChange={setFps}
+                streamSource={selectedStreamSource}
+                onEmptyDataWarning={setHasEmptyDataWarning}
+            />
         </Page>
     );
 };


### PR DESCRIPTION
### Overview
This PR adds a dropdown stream selector to the Stream page, allowing users to switch between different camera sources (external USB webcam, RealSense RGB, and RealSense aligned depth).

### Features
- **Stream Selector Dropdown**: Added dropdown in Stream page header for source selection
- **Multiple Stream Sources**: Support for external USB webcam, RealSense RGB, and RealSense aligned depth
- **Empty Data Warning**: Visual warning badge when stream topic has no data
- **Consistent UI**: Matches styling and behavior of StreamPlayerModal selector

### Changes
- Added `Select` component to Stream page header
- Updated `rosConfig.ts` with new stream source definitions
- Added state management for selected stream source
- Implemented empty data detection and warning display

### Related
- Backend changes in `lucy_ros_packages` repository for camera streaming