### PR TITLE
Linked Lucy Control Panel with ROS 2 Control Joint Interface

### DIFF
--- a/src/Constants/rosConfig.ts
+++ b/src/Constants/rosConfig.ts
@@ -1,7 +1,7 @@
 export const ROS_CONFIG = {
     jointStateTopic: {
-        name: '/joints/right_arm',
-        messageType: 'sensor_msgs/JointState'
+        name: '/right_arm_controller/joint_trajectory',
+        messageType: 'trajectory_msgs/msg/JointTrajectory'
     }
 };
 

--- a/src/Pages/RobotControlPanel.tsx
+++ b/src/Pages/RobotControlPanel.tsx
@@ -141,15 +141,15 @@ export const RobotControlPanel: React.FC = () => {
     /* Fixtures for first demo - awaiting servos indications in urdf */
     const max_hand_angle = 5.236; // approx 300 degrees in radians
     const rightArmFixtures: JointControlState[] = [
-        { name: 'right_shoulder_yaw_joint', currentValue: 2.79, targetValue: 2.79, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Arm' },
-        { name: 'right_shoulder_roll_joint', currentValue: 3.14, targetValue: 3.14, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Arm' },
-        { name: 'right_elbow_joint', currentValue: 1.74, targetValue: 1.74, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Arm' },
-        { name: 'right_wrist_joint', currentValue: 2.62, targetValue: 2.62, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
-        { name: 'right_thumb_joint', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
-        { name: 'right_index_joint', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
-        { name: 'right_middle_joint', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
-        { name: 'right_ring_joint', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
-        { name: 'right_pinky_joint', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
+        { name: 'right_shoulder_yaw', currentValue: 2.79, targetValue: 2.79, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Arm' },
+        { name: 'right_shoulder_roll', currentValue: 3.14, targetValue: 3.14, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Arm' },
+        { name: 'right_elbow', currentValue: 1.74, targetValue: 1.74, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Arm' },
+        { name: 'right_wrist', currentValue: 2.62, targetValue: 2.62, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
+        { name: 'right_thumb', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
+        { name: 'right_index', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
+        { name: 'right_middle', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
+        { name: 'right_ring', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
+        { name: 'right_pinky', currentValue: 0, targetValue: 0, minValue: 0, maxValue: max_hand_angle, type: 'revolute', category: 'Right Hand' },
     ]
 
     const loadUrdfData = () => {

--- a/src/Services/ros/handlers/JointState.handler.ts
+++ b/src/Services/ros/handlers/JointState.handler.ts
@@ -73,7 +73,12 @@ export class JointStateHandler {
         }
 
         const message = new ROSLIB.Message({
-            position: joints.map(j => radianToDegree(j.currentValue)),
+            joint_names: joints.map(j => j.name),
+            points: [
+            {
+                positions: joints.map(j => radianToDegree(j.currentValue)),
+            }
+            ]
         });
         this.jointStateTopic.publish(message);
     }


### PR DESCRIPTION
This PR allows the Control Panel to publish joint states (right arm only as of now) to ROS 2 Control instead of directly talking to the hardware