### PR TITLE
feat(configuration): activate workflow with build and flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/lucy-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Lucy Control Panel - InMoov Robot Interface</title>
-      <style>
-          body {
-              background-color: #000;
-          }
-      </style>
+    <title>Lucy Control Panel</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,15 @@ import { NotFound } from './Pages/NotFound';
 import { ActiveHardwareRosProvider } from './contexts/ActiveHardwareRosContext';
 /* Components */
 import { AuthForm } from './Components/AuthForm';
-import { UI_ACCENT_GREEN, UI_BORDER_STRONG, UI_PANEL_BG } from './Constants/uiTheme.ts';
+import {
+    UI_ACCENT_GREEN,
+    UI_BG_BLACK,
+    UI_BORDER_STRONG,
+    UI_COLOR_TRANSPARENT,
+    UI_PANEL_BG,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SUBTLE,
+} from './Constants/uiTheme.ts';
 
 const Robot3DViewer = lazy(() => import('./Pages/Robot3DViewer').then(module => ({ default: module.default })));
 const Configuration = lazy(() => import('./Pages/Configuration').then(module => ({ default: module.default })));
@@ -56,11 +64,11 @@ function App() {
                     algorithm: theme.darkAlgorithm,
                     token: {
                         colorPrimary: UI_ACCENT_GREEN,
-                        colorBgBase: '#000000',
+                        colorBgBase: UI_BG_BLACK,
                         colorBgContainer: UI_PANEL_BG,
                         colorBorder: UI_BORDER_STRONG,
-                        colorText: '#ffffff',
-                        colorTextSecondary: '#888888',
+                        colorText: UI_TEXT_PRIMARY_ON_DARK,
+                        colorTextSecondary: UI_TEXT_SUBTLE,
                         fontFamily: '"JetBrains Mono", "Fira Code", "Monaco", "Consolas", monospace',
                     },
                 }}
@@ -76,23 +84,23 @@ function App() {
                 algorithm: theme.darkAlgorithm,
                 token: {
                     colorPrimary: UI_ACCENT_GREEN,
-                    colorBgBase: '#000000',
+                    colorBgBase: UI_BG_BLACK,
                     colorBgContainer: UI_PANEL_BG,
                     colorBorder: UI_BORDER_STRONG,
-                    colorText: '#ffffff',
-                    colorTextSecondary: '#888888',
+                    colorText: UI_TEXT_PRIMARY_ON_DARK,
+                    colorTextSecondary: UI_TEXT_SUBTLE,
                     fontFamily: '"JetBrains Mono", "Fira Code", "Monaco", "Consolas", monospace',
                 },
                 components: {
                     Layout: {
-                        bodyBg: '#000000',
+                        bodyBg: UI_BG_BLACK,
                         headerBg: UI_PANEL_BG,
                     },
                     Card: {
                         colorBgContainer: UI_PANEL_BG,
                     },
                     Button: {
-                        colorBgContainer: 'transparent',
+                        colorBgContainer: UI_COLOR_TRANSPARENT,
                     },
                 },
             }}

--- a/src/Components/AuthForm.tsx
+++ b/src/Components/AuthForm.tsx
@@ -2,6 +2,22 @@ import React, { useState } from 'react';
 import { Form, Input, Button, Card, Typography, Alert } from 'antd';
 import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import CryptoJS from 'crypto-js';
+import {
+    UI_ACCENT_GREEN,
+    UI_ACCENT_TEXT_SHADOW,
+    UI_AUTH_ALERT_SURFACE,
+    UI_BORDER_DIM,
+    UI_BORDER_MUTED,
+    UI_CHROME_SURFACE,
+    UI_ERROR_RED,
+    UI_GRADIENT_AUTH_PAGE,
+    UI_PANEL_BG,
+    UI_TEXT_ON_ACCENT,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SECONDARY_MUTED,
+    UI_TEXT_SUBTLE,
+    uiAccentRgba,
+} from '../Constants/uiTheme.ts';
 
 const { Title, Text } = Typography;
 
@@ -59,17 +75,17 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onLogin, error }) => {
             justifyContent: 'center',
             alignItems: 'center',
             minHeight: '100vh',
-            background: 'linear-gradient(135deg, #000000 0%, #0a0a0a 100%)',
+            background: UI_GRADIENT_AUTH_PAGE,
             padding: '20px'
         }}>
             <Card
                 style={{
                     width: '100%',
                     maxWidth: 400,
-                    backgroundColor: '#0a0a0a',
-                    border: '1px solid #333',
+                    backgroundColor: UI_PANEL_BG,
+                    border: `1px solid ${UI_BORDER_MUTED}`,
                     borderRadius: 12,
-                    boxShadow: '0 8px 32px rgba(0, 255, 65, 0.1)'
+                    boxShadow: `0 8px 32px ${uiAccentRgba(0.1)}`
                 }}
                 bodyStyle={{ padding: '40px 32px' }}
             >
@@ -77,15 +93,15 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onLogin, error }) => {
                     <Title 
                         level={2} 
                         style={{ 
-                            color: '#00ff41', 
+                            color: UI_ACCENT_GREEN,
                             fontFamily: 'monospace',
-                            textShadow: '0 0 10px #00ff41',
+                            textShadow: UI_ACCENT_TEXT_SHADOW,
                             margin: 0
                         }}
                     >
                         ▲ LUCY CONTROL PANEL
                     </Title>
-                    <Text style={{ color: '#888', fontFamily: 'monospace', fontSize: 14 }}>
+                    <Text style={{ color: UI_TEXT_SUBTLE, fontFamily: 'monospace', fontSize: 14 }}>
                         Authentication Required
                     </Text>
                 </div>
@@ -94,7 +110,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onLogin, error }) => {
                     <Alert
                         message={error}
                         type="error"
-                        style={{ marginBottom: 24, backgroundColor: '#1a0a0a', borderColor: '#ff4d4f' }}
+                        style={{ marginBottom: 24, backgroundColor: UI_AUTH_ALERT_SURFACE, borderColor: UI_ERROR_RED }}
                     />
                 )}
 
@@ -113,12 +129,12 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onLogin, error }) => {
                         ]}
                     >
                         <Input
-                            prefix={<UserOutlined style={{ color: '#00ff41' }} />}
+                            prefix={<UserOutlined style={{ color: UI_ACCENT_GREEN }} />}
                             placeholder="Username"
                             style={{
-                                backgroundColor: '#0d0d0d',
-                                borderColor: '#333',
-                                color: '#fff',
+                                backgroundColor: UI_CHROME_SURFACE,
+                                borderColor: UI_BORDER_MUTED,
+                                color: UI_TEXT_PRIMARY_ON_DARK,
                                 fontFamily: 'monospace'
                             }}
                         />
@@ -132,12 +148,12 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onLogin, error }) => {
                         ]}
                     >
                         <Input.Password
-                            prefix={<LockOutlined style={{ color: '#00ff41' }} />}
+                            prefix={<LockOutlined style={{ color: UI_ACCENT_GREEN }} />}
                             placeholder="Password"
                             style={{
-                                backgroundColor: '#0d0d0d',
-                                borderColor: '#333',
-                                color: '#fff',
+                                backgroundColor: UI_CHROME_SURFACE,
+                                borderColor: UI_BORDER_MUTED,
+                                color: UI_TEXT_PRIMARY_ON_DARK,
                                 fontFamily: 'monospace'
                             }}
                         />
@@ -151,21 +167,21 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onLogin, error }) => {
                             block
                             style={{
                                 height: 48,
-                                backgroundColor: '#00ff41',
-                                borderColor: '#00ff41',
-                                color: '#000',
+                                backgroundColor: UI_ACCENT_GREEN,
+                                borderColor: UI_ACCENT_GREEN,
+                                color: UI_TEXT_ON_ACCENT,
                                 fontFamily: 'monospace',
                                 fontSize: 16,
                                 fontWeight: 'bold',
-                                boxShadow: '0 0 20px rgba(0, 255, 65, 0.3)',
+                                boxShadow: `0 0 20px ${uiAccentRgba(0.3)}`,
                                 transition: 'all 0.3s ease'
                             }}
                             onMouseEnter={(e) => {
-                                e.currentTarget.style.boxShadow = '0 0 30px rgba(0, 255, 65, 0.5)';
+                                e.currentTarget.style.boxShadow = `0 0 30px ${uiAccentRgba(0.5)}`;
                                 e.currentTarget.style.transform = 'translateY(-2px)';
                             }}
                             onMouseLeave={(e) => {
-                                e.currentTarget.style.boxShadow = '0 0 20px rgba(0, 255, 65, 0.3)';
+                                e.currentTarget.style.boxShadow = `0 0 20px ${uiAccentRgba(0.3)}`;
                                 e.currentTarget.style.transform = 'translateY(0)';
                             }}
                         >
@@ -178,11 +194,11 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onLogin, error }) => {
                     textAlign: 'center', 
                     marginTop: 24,
                     padding: '16px',
-                    backgroundColor: '#0d0d0d',
+                    backgroundColor: UI_CHROME_SURFACE,
                     borderRadius: 8,
-                    border: '1px solid #222'
+                    border: `1px solid ${UI_BORDER_DIM}`
                 }}>
-                    <Text style={{ color: '#666', fontFamily: 'monospace', fontSize: 12 }}>
+                    <Text style={{ color: UI_TEXT_SECONDARY_MUTED, fontFamily: 'monospace', fontSize: 12 }}>
                         Secure access to Lucy's control systems
                     </Text>
                 </div>

--- a/src/Components/DataFlowEffect.tsx
+++ b/src/Components/DataFlowEffect.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UI_ACCENT_GREEN } from '../Constants/uiTheme.ts';
 
 interface DataFlowEffectProps {
   isActive: boolean;
@@ -11,7 +12,7 @@ export const DataFlowEffect: React.FC<DataFlowEffectProps> = ({
   isActive,
   direction = 'horizontal',
   speed = 2,
-  color = '#00ff41'
+  color = UI_ACCENT_GREEN
 }) => {
   if (!isActive) return null;
 

--- a/src/Components/DraggableCategory.tsx
+++ b/src/Components/DraggableCategory.tsx
@@ -4,6 +4,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { JointControlState } from '../Constants/robotTypes';
 import { JointCategory } from './JointCategory';
+import { UI_ACCENT_GREEN, uiAccentRgba } from '../Constants/uiTheme.ts';
 
 interface DraggableCategoryProps {
   id: string;
@@ -56,8 +57,8 @@ export const DraggableCategory: React.FC<DraggableCategoryProps> = ({
                         zIndex: 10,
                         cursor: isBeingDragged ? 'grabbing' : 'grab',
                         padding: '6px 8px',
-                        backgroundColor: 'rgba(0, 255, 65, 0.1)',
-                        border: '1px solid #00ff41',
+                        backgroundColor: uiAccentRgba(0.1),
+                        border: `1px solid ${UI_ACCENT_GREEN}`,
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
@@ -66,15 +67,15 @@ export const DraggableCategory: React.FC<DraggableCategoryProps> = ({
                     }}
                     title="Drag to reorder category"
                     onMouseEnter={(e) => {
-                        e.currentTarget.style.backgroundColor = 'rgba(0, 255, 65, 0.2)';
+                        e.currentTarget.style.backgroundColor = uiAccentRgba(0.2);
                         e.currentTarget.style.transform = 'scale(1.05)';
                     }}
                     onMouseLeave={(e) => {
-                        e.currentTarget.style.backgroundColor = 'rgba(0, 255, 65, 0.1)';
+                        e.currentTarget.style.backgroundColor = uiAccentRgba(0.1);
                         e.currentTarget.style.transform = 'scale(1)';
                     }}
                 >
-                    <DragOutlined style={{ color: '#00ff41', fontSize: 14 }} />
+                    <DragOutlined style={{ color: UI_ACCENT_GREEN, fontSize: 14 }} />
                 </div>
 
                 <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>

--- a/src/Components/HardwareConfigPresetTag.tsx
+++ b/src/Components/HardwareConfigPresetTag.tsx
@@ -1,0 +1,63 @@
+import { Tag } from 'antd';
+import type { CSSProperties } from 'react';
+import {
+    UI_TAG_ACTIVE_PRESET,
+    UI_TAG_FLASHED_PRESET,
+    UI_TAG_LOADED_PRESET,
+    UI_TAG_TARGET_PRESET,
+} from '../Constants/uiTheme.ts';
+
+function headerInner(label: string, value: string) {
+    const show = value.trim() || '—';
+    return (
+        <>
+            <span style={{ fontWeight: 600 }}>{label}:</span> {show}
+        </>
+    );
+}
+
+/** Header / toolbar: rounded `Tag` — ACTIVE cyan, TARGET orange, FLASHED purple, LOADED blue. */
+export function HardwareConfigPresetHeaderTag(props: {
+    variant: 'active' | 'target' | 'flashed' | 'loaded';
+    /** Without trailing colon, e.g. ACTIVE or TARGET */
+    label: string;
+    value: string;
+    title?: string;
+}) {
+    const { variant, label, value, title } = props;
+    const inner = headerInner(label, value);
+    const color =
+        variant === 'active'
+            ? UI_TAG_ACTIVE_PRESET
+            : variant === 'flashed'
+              ? UI_TAG_FLASHED_PRESET
+              : variant === 'loaded'
+                ? UI_TAG_LOADED_PRESET
+                : UI_TAG_TARGET_PRESET;
+    return (
+        <Tag color={color} title={title}>
+            {inner}
+        </Tag>
+    );
+}
+
+/** Compact row pill: ACTIVE / TARGET / FLASHED (load modal list). */
+export function HardwareConfigPresetRoleTag(props: {
+    variant: 'active' | 'target' | 'flashed';
+    style?: CSSProperties;
+}) {
+    const text =
+        props.variant === 'active' ? 'ACTIVE' : props.variant === 'target' ? 'TARGET' : 'FLASHED';
+    const color =
+        props.variant === 'active'
+            ? UI_TAG_ACTIVE_PRESET
+            : props.variant === 'flashed'
+              ? UI_TAG_FLASHED_PRESET
+              : UI_TAG_TARGET_PRESET;
+    const merged: CSSProperties = { marginInlineEnd: 0, ...props.style };
+    return (
+        <Tag color={color} style={merged}>
+            {text}
+        </Tag>
+    );
+}

--- a/src/Components/HardwareYamlConfigManager.tsx
+++ b/src/Components/HardwareYamlConfigManager.tsx
@@ -6,15 +6,18 @@ import {
     Input,
     List,
     Modal,
+    Popconfirm,
     Row,
     Space,
     Tooltip,
     Typography,
     message,
 } from 'antd';
+import { HardwareConfigPresetRoleTag } from './HardwareConfigPresetTag.tsx';
 import {
     AimOutlined,
     CloudDownloadOutlined,
+    DeleteOutlined,
     DownloadOutlined,
     FolderOpenOutlined,
     ReloadOutlined,
@@ -25,8 +28,13 @@ import {
     UI_BORDER_MUTED,
     UI_BORDER_SOFT,
     UI_CARD_SURFACE_STYLE,
+    UI_COLOR_TRANSPARENT,
+    UI_INPUT_SURFACE,
+    UI_LIST_ROW_BG,
+    UI_MODAL_MASK_BG,
     UI_PRIMARY_GREEN_BUTTON_STYLE,
-    UI_WARNING_AMBER,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SUBTLE,
 } from '../Constants/uiTheme.ts';
 
 const { Text, Title } = Typography;
@@ -44,14 +52,20 @@ export interface HardwareYamlConfigManagerProps {
     sensorPressureCount: number;
     savedConfigNames: string[];
     activeConfigName: string;
+    /** Last pipeline-flashed preset (from config/get / active_meta); shown in load list. */
+    flashedConfigName: string;
     configListLoading: boolean;
-    /** Selection used by ACTIVATE / DELETE toolbar on the parent page */
+    /** Selection used by ACTIVATE workflow on the parent page */
     toolbarTargetConfig: string;
     onToolbarTargetConfigChange: (configName: string) => void;
     onRefreshConfigList: () => void | Promise<void>;
+    deleteConfigByName: (configName: string) => Promise<boolean>;
+    deletingConfig: boolean;
     onSaveConfig: (trimmedName: string) => Promise<boolean>;
     /** Named configuration file, or empty string for active */
     onLoadConfig: (configName: string) => Promise<boolean>;
+    /** Blocks save/load UI (e.g. while ConfigurePipeline is running). */
+    workflowLocked?: boolean;
 }
 
 export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps> = ({
@@ -65,12 +79,16 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
     sensorPressureCount,
     savedConfigNames,
     activeConfigName,
+    flashedConfigName,
     configListLoading,
     toolbarTargetConfig,
     onToolbarTargetConfigChange,
     onRefreshConfigList,
+    deleteConfigByName,
+    deletingConfig,
     onSaveConfig,
     onLoadConfig,
+    workflowLocked = false,
 }) => {
     const [saveModalVisible, setSaveModalVisible] = useState(false);
     const [loadModalVisible, setLoadModalVisible] = useState(false);
@@ -97,76 +115,82 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
             try {
                 const ok = await onLoadConfig(configKey);
                 if (ok) {
-                    message.success(
-                        configKey.trim()
-                            ? `LOADED CONFIGURATION "${configKey.trim()}"`
-                            : `LOADED ACTIVE CONFIGURATION (${activeConfigName || 'robot'})`,
-                    );
+                    message.success(`LOADED CONFIGURATION "${configKey.trim()}"`);
                     setLoadModalVisible(false);
                 }
             } finally {
                 setBusyLoadId(null);
             }
         },
-        [onLoadConfig, activeConfigName],
+        [onLoadConfig],
     );
 
     const modalStyles = {
-        mask: { backgroundColor: 'rgba(0, 0, 0, 0.8)' },
+        mask: { backgroundColor: UI_MODAL_MASK_BG },
     };
 
     const inputDarkStyle = {
-        backgroundColor: '#1a1a1a',
-        borderColor: '#444',
-        color: '#fff',
+        backgroundColor: UI_INPUT_SURFACE,
+        borderColor: UI_BORDER_SOFT,
+        color: UI_TEXT_PRIMARY_ON_DARK,
     };
 
     const outlineBtnStyle = {
-        backgroundColor: 'transparent',
+        backgroundColor: UI_COLOR_TRANSPARENT,
         borderColor: UI_BORDER_SOFT,
-        color: '#fff',
+        color: UI_TEXT_PRIMARY_ON_DARK,
     };
 
     const activeTrim = activeConfigName.trim();
-    const namedRows = activeTrim
-        ? savedConfigNames.filter((n) => n.trim() !== activeTrim)
-        : [...savedConfigNames];
+    const flashedTrim = flashedConfigName.trim();
 
-    const activeRows = [
-        {
-            key: '__active__',
-            title: 'ACTIVE CONFIGURATION (ON ROBOT)',
-            subtitle: `RESOLVED NAME: ${activeConfigName || '—'}`,
-            loadArg: '',
+    const canDeletePresetFile = useCallback(
+        (presetName: string) => {
+            const n = presetName.trim();
+            if (!n || workflowLocked || !isConnected || deletingConfig) return false;
+            if (n === 'default') return false;
+            if (n === activeTrim) return false;
+            return true;
         },
-        ...namedRows.map((n) => ({
-            key: n,
-            title: n.toUpperCase(),
-            subtitle: 'NAMED CONFIGURATION UNDER CONFIGS/',
-            loadArg: n,
-        })),
-    ];
+        [activeTrim, deletingConfig, isConnected, workflowLocked],
+    );
+
+    const sortedUnique = [...new Set(savedConfigNames.map((s) => s.trim()).filter(Boolean))].sort((a, b) =>
+        a.localeCompare(b),
+    );
+
+    /** Active preset first when known; otherwise alphabetical. Includes active name even if missing from list yet. */
+    let orderedPresets: string[];
+    if (activeTrim && sortedUnique.includes(activeTrim)) {
+        orderedPresets = [activeTrim, ...sortedUnique.filter((n) => n !== activeTrim)];
+    } else if (activeTrim) {
+        orderedPresets = [activeTrim, ...sortedUnique];
+    } else {
+        orderedPresets = sortedUnique;
+    }
+
+    const presetRows = orderedPresets.map((name) => ({ key: name, name }));
 
     return (
         <>
             <Space>
                 <Button
-                    icon={<SaveOutlined />}
-                    disabled={!isConnected || !yamlDoc || !isDirty}
-                    onClick={() => setSaveModalVisible(true)}
-                    style={outlineBtnStyle}
-                >
-                    SAVE CONFIG
-                </Button>
-
-                <Button
                     icon={<FolderOpenOutlined />}
-                    disabled={!isConnected}
+                    disabled={workflowLocked || !isConnected}
                     onClick={() => setLoadModalVisible(true)}
                     style={outlineBtnStyle}
                 >
                     LOAD CONFIG{' '}
                     {savedConfigCount > 0 ? <span style={{ color: UI_ACCENT_GREEN }}>({savedConfigCount})</span> : null}
+                </Button>
+
+                <Button
+                    icon={<SaveOutlined />}
+                    disabled={workflowLocked || !isConnected || !yamlDoc || !isDirty}
+                    onClick={() => setSaveModalVisible(true)}
+                    style={outlineBtnStyle}
+                >
+                    SAVE CONFIG
                 </Button>
             </Space>
 
@@ -209,7 +233,7 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
                     />
 
                     <div>
-                        <Text style={{ color: '#888', fontSize: 12, marginBottom: 8, display: 'block' }}>
+                        <Text style={{ color: UI_TEXT_SUBTLE, fontSize: 12, marginBottom: 8, display: 'block' }}>
                             QUICK SUGGESTIONS:
                         </Text>
                         <Space wrap>
@@ -220,9 +244,9 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
                                     type="dashed"
                                     onClick={() => setConfigNameInput(suggestion)}
                                     style={{
-                                        borderColor: '#444',
-                                        color: '#888',
-                                        backgroundColor: 'transparent',
+                                        borderColor: UI_BORDER_SOFT,
+                                        color: UI_TEXT_SUBTLE,
+                                        backgroundColor: UI_COLOR_TRANSPARENT,
                                     }}
                                 >
                                     {suggestion.toUpperCase()}
@@ -234,19 +258,19 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
                     <Card size="small" style={{ ...UI_CARD_SURFACE_STYLE }}>
                         <Row gutter={16}>
                             <Col span={8}>
-                                <Text strong style={{ color: '#fff' }}>
+                                <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK }}>
                                     ROBOT_NAME:
                                 </Text>{' '}
                                 <Text style={{ color: UI_ACCENT_GREEN }}>{hardwareRobotName || '—'}</Text>
                             </Col>
                             <Col span={8}>
-                                <Text strong style={{ color: '#fff' }}>
+                                <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK }}>
                                     ACTUATORS:
                                 </Text>{' '}
                                 <Text style={{ color: UI_ACCENT_GREEN }}>{actuatorCount}</Text>
                             </Col>
                             <Col span={8}>
-                                <Text strong style={{ color: '#fff' }}>
+                                <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK }}>
                                     PRESSURE SENSORS:
                                 </Text>{' '}
                                 <Text style={{ color: UI_ACCENT_GREEN }}>{sensorPressureCount}</Text>
@@ -263,11 +287,11 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
                     </Title>
                 }
                 open={loadModalVisible}
-                footer={[
-                    <Button key="close" onClick={() => setLoadModalVisible(false)} style={outlineBtnStyle}>
+                footer={
+                    <Button onClick={() => setLoadModalVisible(false)} style={outlineBtnStyle}>
                         CLOSE
-                    </Button>,
-                ]}
+                    </Button>
+                }
                 onCancel={() => setLoadModalVisible(false)}
                 width={720}
                 style={{ top: 50 }}
@@ -275,14 +299,10 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
                 className="dark-modal"
             >
                 <Space direction="vertical" style={{ width: '100%', marginBottom: 12 }} size="small">
-                    <Text style={{ color: '#888', fontSize: 12 }}>
-                        TOOLBAR TARGET FOR ACTIVATE / DELETE:{' '}
-                        <Text style={{ color: UI_ACCENT_GREEN }}>{toolbarTargetConfig.trim() || '—'}</Text>
-                    </Text>
                     <Button
                         size="small"
                         icon={<ReloadOutlined spin={configListLoading} />}
-                        disabled={!isConnected || configListLoading}
+                        disabled={workflowLocked || !isConnected || configListLoading}
                         onClick={() => void onRefreshConfigList()}
                         style={outlineBtnStyle}
                     >
@@ -292,19 +312,31 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
 
                 {!isConnected ? (
                     <Card style={{ textAlign: 'center', ...UI_CARD_SURFACE_STYLE }}>
-                        <Text style={{ color: '#888' }}>CONNECT TO ROS BRIDGE FIRST.</Text>
+                        <Text style={{ color: UI_TEXT_SUBTLE }}>CONNECT TO ROS BRIDGE FIRST.</Text>
                     </Card>
                 ) : (
                     <List
-                        dataSource={activeRows}
+                        dataSource={presetRows}
+                        locale={{
+                            emptyText: (
+                                <Text type="secondary">
+                                    NO PRESETS FROM CONFIG/LIST — TRY REFRESH OR CHECK ROBOT CONNECTION.
+                                </Text>
+                            ),
+                        }}
                         renderItem={(row) => {
-                            const isActiveRow = row.key === '__active__';
-                            const rowBusy = busyLoadId !== null && busyLoadId === row.loadArg;
+                            const name = row.name;
+                            const rowBusy = busyLoadId !== null && busyLoadId === name;
+                            const isRobotActive = Boolean(activeTrim) && name === activeTrim;
+                            const isFlashedPreset = Boolean(flashedTrim) && name === flashedTrim;
+                            const isActivateTarget = name === toolbarTargetConfig.trim();
+                            const showRowDelete = !isRobotActive;
+
                             return (
                                 <List.Item
                                     key={row.key}
                                     style={{
-                                        backgroundColor: '#0c0c0c',
+                                        backgroundColor: UI_LIST_ROW_BG,
                                         marginBottom: 8,
                                         borderRadius: 4,
                                         padding: 12,
@@ -316,53 +348,78 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
                                                 type="primary"
                                                 icon={<DownloadOutlined />}
                                                 loading={loadingConfig && rowBusy}
-                                                disabled={loadingConfig && busyLoadId !== row.loadArg}
-                                                onClick={() => void handleLoadConfig(row.loadArg)}
+                                                disabled={
+                                                    workflowLocked || (loadingConfig && busyLoadId !== name)
+                                                }
+                                                onClick={() => void handleLoadConfig(name)}
                                                 style={UI_PRIMARY_GREEN_BUTTON_STYLE}
                                             >
                                                 LOAD
                                             </Button>
                                         </Tooltip>,
-                                        <Tooltip key="target" title="ONLY SET ACTIVATE / DELETE TARGET (NO FETCH)">
+                                        <Tooltip key="target" title="SET AS TARGET FOR ACTIVATE WORKFLOW">
                                             <Button
                                                 icon={<AimOutlined />}
-                                                disabled={loadingConfig}
+                                                disabled={workflowLocked || loadingConfig}
                                                 onClick={() => {
-                                                    const targetName = isActiveRow ? activeConfigName.trim() : row.loadArg;
-                                                    onToolbarTargetConfigChange(targetName);
-                                                    message.info(
-                                                        isActiveRow && !targetName
-                                                            ? 'TOOLBAR TARGET: ACTIVE CONFIGURATION'
-                                                            : `TOOLBAR TARGET: "${targetName}"`,
-                                                    );
+                                                    onToolbarTargetConfigChange(name);
+                                                    message.info(`TOOLBAR TARGET: "${name}"`);
                                                 }}
                                                 style={outlineBtnStyle}
                                             >
                                                 TARGET
                                             </Button>
                                         </Tooltip>,
+                                        ...(showRowDelete
+                                            ? [
+                                                  <Popconfirm
+                                                      key="del-preset"
+                                                      title="DELETE ?"
+                                                      okText="DELETE"
+                                                      cancelText="CANCEL"
+                                                      okButtonProps={{ danger: true }}
+                                                      onConfirm={() => void deleteConfigByName(name)}
+                                                  >
+                                                      <Button
+                                                          type="text"
+                                                          size="small"
+                                                          danger
+                                                          icon={<DeleteOutlined />}
+                                                          aria-label={`Delete configuration ${name}`}
+                                                          disabled={
+                                                              !canDeletePresetFile(name) ||
+                                                              workflowLocked ||
+                                                              loadingConfig
+                                                          }
+                                                      />
+                                                  </Popconfirm>,
+                                              ]
+                                            : []),
                                     ]}
                                 >
                                     <List.Item.Meta
                                         title={
-                                            <Space size={8}>
+                                            <Space size={8} wrap>
                                                 <Text strong style={{ fontSize: 16, color: UI_ACCENT_GREEN }}>
-                                                    {row.title}
+                                                    {name.toUpperCase()}
                                                 </Text>
-                                                {(isActiveRow
-                                                    ? Boolean(activeConfigName.trim()) &&
-                                                      activeConfigName.trim() === toolbarTargetConfig.trim()
-                                                    : row.loadArg === toolbarTargetConfig.trim()) ? (
-                                                    <Text style={{ color: UI_WARNING_AMBER, fontSize: 11 }}>TARGET</Text>
+                                                {isRobotActive ? (
+                                                    <HardwareConfigPresetRoleTag variant="active" />
+                                                ) : null}
+                                                {isFlashedPreset ? (
+                                                    <HardwareConfigPresetRoleTag variant="flashed" />
+                                                ) : null}
+                                                {isActivateTarget ? (
+                                                    <HardwareConfigPresetRoleTag variant="target" />
                                                 ) : null}
                                             </Space>
                                         }
                                         description={
-                                            <Space direction="vertical" size={4}>
-                                                <Space>
-                                                    <CloudDownloadOutlined style={{ color: '#888' }} />
-                                                    <Text style={{ color: '#888' }}>{row.subtitle}</Text>
-                                                </Space>
+                                            <Space size={4}>
+                                                <CloudDownloadOutlined style={{ color: UI_TEXT_SUBTLE }} />
+                                                <Text style={{ color: UI_TEXT_SUBTLE, fontSize: 12 }}>
+                                                    config/hardware/configs/{name}.yaml
+                                                </Text>
                                             </Space>
                                         }
                                     />

--- a/src/Components/JointCategory.tsx
+++ b/src/Components/JointCategory.tsx
@@ -3,6 +3,14 @@ import { Card, Typography, Space, Button, Badge } from 'antd';
 import { ReloadOutlined } from '@ant-design/icons';
 import type { JointControlState } from '../Constants/robotTypes';
 import { JointControl } from './JointControl';
+import {
+    UI_BORDER_MUTED,
+    UI_BORDER_SOFT,
+    UI_COLOR_TRANSPARENT,
+    UI_PANEL_BG,
+    UI_TEXT_ON_ACCENT,
+    UI_TEXT_PRIMARY_ON_DARK,
+} from '../Constants/uiTheme.ts';
 
 const { Title } = Typography;
 
@@ -37,8 +45,8 @@ export const JointCategory: React.FC<JointCategoryProps> = React.memo(({
         <Card
             style={{
                 marginBottom: 16,
-                backgroundColor: '#0a0a0a',
-                borderColor: '#333',
+                backgroundColor: UI_PANEL_BG,
+                borderColor: UI_BORDER_MUTED,
                 borderLeft: `2px solid ${categoryColor}`,
                 height: '100%',
                 display: 'flex',
@@ -82,7 +90,7 @@ export const JointCategory: React.FC<JointCategoryProps> = React.memo(({
                     count={joints.length}
                     style={{
                         backgroundColor: categoryColor,
-                        color: '#000',
+                        color: UI_TEXT_ON_ACCENT,
                         fontWeight: 'bold'
                     }}
                 />
@@ -96,9 +104,9 @@ export const JointCategory: React.FC<JointCategoryProps> = React.memo(({
                 handleResetCategory();
                 }}
                 style={{
-                backgroundColor: 'transparent',
-                borderColor: '#444',
-                color: '#fff'
+                backgroundColor: UI_COLOR_TRANSPARENT,
+                borderColor: UI_BORDER_SOFT,
+                color: UI_TEXT_PRIMARY_ON_DARK
                 }}
                 title={`Reset all ${category} joints to their rest value`}
             >

--- a/src/Components/JointControl.tsx
+++ b/src/Components/JointControl.tsx
@@ -3,6 +3,14 @@ import { Card, Slider, InputNumber, Typography, Space, Tag } from 'antd';
 import type { JointControlState } from '../Constants/robotTypes';
 
 import { radianToDegree, degreeToRadian } from "../Utils/math.utils.ts";
+import {
+    UI_BORDER_MUTED,
+    UI_BORDER_SOFT,
+    UI_INPUT_SURFACE,
+    UI_LIST_ROW_BG,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SECONDARY_MUTED,
+} from '../Constants/uiTheme.ts';
 
 const { Text } = Typography;
 
@@ -84,15 +92,15 @@ export const JointControl: React.FC<JointControlProps> = React.memo(({
       size="small"
       style={{
         marginBottom: 8,
-        backgroundColor: '#0c0c0c',
-        borderColor: '#333',
-        color: '#fff'
+        backgroundColor: UI_LIST_ROW_BG,
+        borderColor: UI_BORDER_MUTED,
+        color: UI_TEXT_PRIMARY_ON_DARK
       }}
       bodyStyle={{ padding: 12 }}
     >
       <Space direction="vertical" style={{ width: '100%' }} size="small">
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <Text strong style={{ color: '#fff', fontSize: '12px' }}>
+          <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK, fontSize: '12px' }}>
             {joint.name.replace(/_link_joint$/, '').replace(/i01\./, '')}
           </Text>
           <Tag color={getJointTypeColor(joint.type)}>
@@ -124,14 +132,14 @@ export const JointControl: React.FC<JointControlProps> = React.memo(({
             size="small"
             style={{
               width: 80,
-              backgroundColor: '#1a1a1a',
-              borderColor: '#444'
+              backgroundColor: UI_INPUT_SURFACE,
+              borderColor: UI_BORDER_SOFT
             }}
             addonAfter={showDegrees ? '°' : 'rad'}
           />
         </div>
 
-        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '10px', color: '#666' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '10px', color: UI_TEXT_SECONDARY_MUTED }}>
           <Text type="secondary" style={{ fontSize: '10px' }}>
             Min: {minDisplay}{showDegrees ? '°' : 'rad'}
           </Text>

--- a/src/Components/LucyControlPanelHeader.tsx
+++ b/src/Components/LucyControlPanelHeader.tsx
@@ -5,10 +5,16 @@ import { ConnectedClientsHandler } from '../Services/ros/handlers/ConnectedClien
 import {
     UI_ACCENT_BOX_SHADOW_SOFT,
     UI_ACCENT_GREEN,
+    UI_ACCENT_ORANGE,
     UI_ACCENT_TEXT_SHADOW,
     UI_BORDER_MUTED,
     UI_BORDER_SOFT,
+    UI_CHROME_SURFACE,
+    UI_COLOR_TRANSPARENT,
     UI_ERROR_RED,
+    UI_TEXT_ON_ACCENT,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SECONDARY_MUTED,
 } from '../Constants/uiTheme.ts';
 
 const { Text } = Typography;
@@ -98,19 +104,19 @@ export const LucyControlPanelHeader: React.FC<LucyControlPanelHeaderProps> = ({ 
 
     const getConnectionStatusColor = () => {
         if (countState > 1) {
-            return '#ffa500';
+            return UI_ACCENT_ORANGE;
         }
         switch (connectionStatus) {
             case 'connected':
                 return UI_ACCENT_GREEN;
             case 'connecting':
-                return '#ffa500';
+                return UI_ACCENT_ORANGE;
             case 'reconnecting':
-                return '#ffa500';
+                return UI_ACCENT_ORANGE;
             case 'disconnected':
                 return UI_ERROR_RED;
             default:
-                return '#666';
+                return UI_TEXT_SECONDARY_MUTED;
         }
     };
 
@@ -163,7 +169,7 @@ export const LucyControlPanelHeader: React.FC<LucyControlPanelHeaderProps> = ({ 
                                 gap: 8,
                                 padding: '4px 10px',
                                 borderRadius: 16,
-                                backgroundColor: '#0d0d0d',
+                                backgroundColor: UI_CHROME_SURFACE,
                                 border: `1px solid ${UI_BORDER_MUTED}`,
                             }}
                         >
@@ -194,9 +200,9 @@ export const LucyControlPanelHeader: React.FC<LucyControlPanelHeaderProps> = ({ 
                             disabled={isConnecting || isReconnecting}
                             style={{
                                 width: 200,
-                                backgroundColor: '#0d0d0d',
+                                backgroundColor: UI_CHROME_SURFACE,
                                 borderColor: UI_BORDER_MUTED,
-                                color: '#fff',
+                                color: UI_TEXT_PRIMARY_ON_DARK,
                                 fontFamily: 'monospace',
                                 fontSize: 12,
                             }}
@@ -206,8 +212,8 @@ export const LucyControlPanelHeader: React.FC<LucyControlPanelHeaderProps> = ({ 
                             onClick={() => void handleConnect()}
                             disabled={isConnecting || isReconnecting}
                             style={{
-                                backgroundColor: isConnected ? 'transparent' : UI_ACCENT_GREEN,
-                                color: isConnected ? '#fff' : '#000',
+                                backgroundColor: isConnected ? UI_COLOR_TRANSPARENT : UI_ACCENT_GREEN,
+                                color: isConnected ? UI_TEXT_PRIMARY_ON_DARK : UI_TEXT_ON_ACCENT,
                                 borderColor: isConnected ? UI_BORDER_SOFT : UI_ACCENT_GREEN,
                                 boxShadow: isConnected ? 'none' : UI_ACCENT_BOX_SHADOW_SOFT,
                             }}
@@ -219,10 +225,12 @@ export const LucyControlPanelHeader: React.FC<LucyControlPanelHeaderProps> = ({ 
                             onClick={() => void handleReconnect()}
                             disabled={isDisconnected || isConnecting || isReconnecting}
                             style={{
-                                backgroundColor: isConnected || isReconnecting ? '#ffa500' : 'transparent',
-                                color: isConnected || isReconnecting ? '#000' : '#fff',
-                                borderColor: isConnected || isReconnecting ? '#ffa500' : UI_BORDER_SOFT,
-                                boxShadow: isConnected || isReconnecting ? '0 0 8px #ffa500' : 'none',
+                                backgroundColor:
+                                    isConnected || isReconnecting ? UI_ACCENT_ORANGE : UI_COLOR_TRANSPARENT,
+                                color: isConnected || isReconnecting ? UI_TEXT_ON_ACCENT : UI_TEXT_PRIMARY_ON_DARK,
+                                borderColor: isConnected || isReconnecting ? UI_ACCENT_ORANGE : UI_BORDER_SOFT,
+                                boxShadow:
+                                    isConnected || isReconnecting ? `0 0 8px ${UI_ACCENT_ORANGE}` : 'none',
                             }}
                         >
                             {isReconnecting ? 'RECONNECTING...' : 'RECONNECT'}
@@ -264,11 +272,11 @@ export const ControlPanelHeaderStats: React.FC<{ jointCount: number; categoryCou
         }}
     >
         <span style={{ fontSize: 12, whiteSpace: 'nowrap' }}>
-            <span style={{ color: '#666', fontSize: 10 }}>TOTAL JOINTS </span>
+            <span style={{ color: UI_TEXT_SECONDARY_MUTED, fontSize: 10 }}>TOTAL JOINTS </span>
             <span style={{ color: UI_ACCENT_GREEN, fontSize: 16 }}>{jointCount}</span>
         </span>
         <span style={{ fontSize: 12, whiteSpace: 'nowrap' }}>
-            <span style={{ color: '#666', fontSize: 10 }}>CATEGORIES </span>
+            <span style={{ color: UI_TEXT_SECONDARY_MUTED, fontSize: 10 }}>CATEGORIES </span>
             <span style={{ color: UI_ACCENT_GREEN, fontSize: 16 }}>{categoryCount}</span>
         </span>
     </div>

--- a/src/Components/MediapipeHandTracker.tsx
+++ b/src/Components/MediapipeHandTracker.tsx
@@ -4,6 +4,13 @@ import Webcam from "react-webcam";
 import { Camera } from "@mediapipe/camera_utils";
 import { drawConnectors, drawLandmarks } from "@mediapipe/drawing_utils";
 import { HANDS_MODEL_CONFIG, MEDIAPIPE_HANDS_URL } from "../Constants/MediaPipe";
+import {
+    UI_CANVAS_LIME,
+    UI_CANVAS_RED,
+    UI_OVERLAY_BACKDROP_SOFT,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_VIDEO_OVERLAY_CYAN,
+} from "../Constants/uiTheme.ts";
 
 interface MediapipeHandTrackerProps {
     width?: number;
@@ -41,10 +48,10 @@ const MediapipeHandTracker: React.FC<MediapipeHandTrackerProps> = ({
             // results.multiHandLandmarks [[], []]
             for (const landmarks of results.multiHandLandmarks) {
                 drawConnectors(ctx, landmarks, HAND_CONNECTIONS, {
-                    color: "#00FF00",
+                    color: UI_CANVAS_LIME,
                     lineWidth: 4,
                 });
-                drawLandmarks(ctx, landmarks, { color: "#FF0000", lineWidth: 2 });
+                drawLandmarks(ctx, landmarks, { color: UI_CANVAS_RED, lineWidth: 2 });
                 //TODO Temporary poc, move index from top to bottom
                 // Get the index fingertip (landmark #8)
                 const indexTipLandmark = landmarks[8];
@@ -57,7 +64,7 @@ const MediapipeHandTracker: React.FC<MediapipeHandTrackerProps> = ({
 
                     ctx.beginPath();
                     ctx.arc(x, y, 8, 0, 2 * Math.PI);
-                    ctx.fillStyle = "cyan";
+                    ctx.fillStyle = UI_VIDEO_OVERLAY_CYAN;
                     ctx.fill();
                 }
             }
@@ -135,8 +142,8 @@ const MediapipeHandTracker: React.FC<MediapipeHandTrackerProps> = ({
                         bottom: "20px",
                         left: "50%",
                         transform: "translateX(-50%)",
-                        background: "rgba(0,0,0,0.6)",
-                        color: "white",
+                        background: UI_OVERLAY_BACKDROP_SOFT,
+                        color: UI_TEXT_PRIMARY_ON_DARK,
                         padding: "10px 20px",
                         borderRadius: "10px",
                         fontFamily: "monospace",

--- a/src/Components/MovableModal.tsx
+++ b/src/Components/MovableModal.tsx
@@ -1,5 +1,13 @@
 import React, { useRef, useState, type ReactNode } from 'react';
 import { Button, Space } from 'antd';
+import {
+    UI_ACCENT_GREEN,
+    UI_BORDER_DIM,
+    UI_BORDER_MUTED,
+    UI_GRADIENT_MODAL_HEADER,
+    UI_MODAL_SURFACE,
+    UI_SHADOW_ELEVATED,
+} from '../Constants/uiTheme.ts';
 
 interface MediapipeHandTrackerModalProps {
     children: ReactNode;
@@ -98,10 +106,10 @@ export function MovableModal({
                 width: w,
                 height: h,
                 zIndex: 1000,
-                backgroundColor: '#0b0b0b',
-                border: '1px solid #333',
+                backgroundColor: UI_MODAL_SURFACE,
+                border: `1px solid ${UI_BORDER_MUTED}`,
                 borderRadius: 8,
-                boxShadow: '0 8px 24px rgba(0,0,0,0.6)',
+                boxShadow: UI_SHADOW_ELEVATED,
                 overflow: 'hidden',
                 userSelect: 'none',
             }}
@@ -115,13 +123,13 @@ export function MovableModal({
                     alignItems: 'center',
                     justifyContent: 'space-between',
                     padding: '0 8px',
-                    background: 'linear-gradient(180deg, #121212, #0b0b0b)',
-                    borderBottom: '1px solid #222',
+                    background: UI_GRADIENT_MODAL_HEADER,
+                    borderBottom: `1px solid ${UI_BORDER_DIM}`,
                     cursor: 'move',
                 }}
             >
                 <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-                    <span style={{ color: '#00ff41', fontFamily: 'monospace', fontSize: 12 }}>
+                    <span style={{ color: UI_ACCENT_GREEN, fontFamily: 'monospace', fontSize: 12 }}>
                         {modalName}
                     </span>
                     {header}
@@ -144,7 +152,7 @@ export function MovableModal({
                     width: 14,
                     height: 14,
                     cursor: 'nwse-resize',
-                    background: 'linear-gradient(135deg, transparent 50%, #333 50%)',
+                    background: `linear-gradient(135deg, transparent 50%, ${UI_BORDER_MUTED} 50%)`,
                 }}
             />
         </div>

--- a/src/Components/Navigation.tsx
+++ b/src/Components/Navigation.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Button, Space } from 'antd';
 import { EyeOutlined, ControlOutlined, CameraOutlined, SettingOutlined } from '@ant-design/icons';
+import {
+    UI_ACCENT_GREEN,
+    UI_BORDER_MUTED,
+    UI_BORDER_SOFT,
+    UI_COLOR_TRANSPARENT,
+    UI_NAV_BAR_BG,
+    UI_TEXT_ON_ACCENT,
+    UI_TEXT_PRIMARY_ON_DARK,
+} from '../Constants/uiTheme.ts';
 
 const navigationItems = [
     { to: '/', label: 'CONTROL', icon: <ControlOutlined /> },
@@ -20,9 +29,9 @@ export const Navigation: React.FC = () => {
                 bottom: 16,
                 right: 16,
                 zIndex: 1000,
-                backgroundColor: 'rgba(10, 10, 10, 0.9)',
+                backgroundColor: UI_NAV_BAR_BG,
                 padding: '8px',
-                border: '1px solid #333',
+                border: `1px solid ${UI_BORDER_MUTED}`,
                 borderRadius: '0'
                 }}
         >
@@ -33,9 +42,10 @@ export const Navigation: React.FC = () => {
                             type={location.pathname === item.to ? 'primary' : 'default'}
                             icon={item.icon}
                             style={{
-                                backgroundColor: location.pathname === item.to ? '#00ff41' : 'transparent',
-                                borderColor: location.pathname === item.to ? '#00ff41' : '#444',
-                                color: location.pathname === item.to ? '#000' : '#fff',
+                                backgroundColor:
+                                    location.pathname === item.to ? UI_ACCENT_GREEN : UI_COLOR_TRANSPARENT,
+                                borderColor: location.pathname === item.to ? UI_ACCENT_GREEN : UI_BORDER_SOFT,
+                                color: location.pathname === item.to ? UI_TEXT_ON_ACCENT : UI_TEXT_PRIMARY_ON_DARK,
                                 fontWeight: 'bold',
                                 fontSize: '11px'
                             }}

--- a/src/Components/PoseManager.tsx
+++ b/src/Components/PoseManager.tsx
@@ -21,6 +21,19 @@ import {
   ClockCircleOutlined
 } from '@ant-design/icons';
 import type { JointControlState } from '../Constants/robotTypes';
+import {
+    UI_ACCENT_GREEN,
+    UI_BORDER_MUTED,
+    UI_BORDER_SOFT,
+    UI_COLOR_TRANSPARENT,
+    UI_INPUT_SURFACE,
+    UI_LIST_ROW_BG,
+    UI_MODAL_MASK_BG,
+    UI_PANEL_BG,
+    UI_PRIMARY_GREEN_BUTTON_STYLE,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SUBTLE,
+} from '../Constants/uiTheme.ts';
 import { storageService, type SavedPose } from '../Services/storage.service.ts';
 
 const { Text, Title } = Typography;
@@ -136,9 +149,9 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
           icon={<SaveOutlined />}
           onClick={() => setSaveModalVisible(true)}
           style={{
-            backgroundColor: 'transparent',
-            borderColor: '#444',
-            color: '#fff'
+            backgroundColor: UI_COLOR_TRANSPARENT,
+            borderColor: UI_BORDER_SOFT,
+            color: UI_TEXT_PRIMARY_ON_DARK
           }}
         >
           SAVE POSE
@@ -148,19 +161,19 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
           icon={<FolderOpenOutlined />}
           onClick={() => setLoadModalVisible(true)}
           style={{
-            backgroundColor: 'transparent',
-            borderColor: '#444',
-            color: '#fff'
+            backgroundColor: UI_COLOR_TRANSPARENT,
+            borderColor: UI_BORDER_SOFT,
+            color: UI_TEXT_PRIMARY_ON_DARK
           }}
         >
-          LOAD POSE {poseCount > 0 && <span style={{ color: '#00ff41' }}>({poseCount})</span>}
+          LOAD POSE {poseCount > 0 && <span style={{ color: UI_ACCENT_GREEN }}>({poseCount})</span>}
         </Button>
       </Space>
 
       {/* Save Pose Modal */}
       <Modal
         title={
-          <Title level={4} style={{ color: '#00ff41', margin: 0 }}>
+          <Title level={4} style={{ color: UI_ACCENT_GREEN, margin: 0 }}>
             <SaveOutlined /> Save Current Pose
           </Title>
         }
@@ -175,15 +188,15 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
         cancelText="Cancel"
         style={{ top: 100 }}
         styles={{
-          mask: { backgroundColor: 'rgba(0, 0, 0, 0.8)' }
+          mask: { backgroundColor: UI_MODAL_MASK_BG }
         }}
         className="dark-modal"
       >
                 <Space direction="vertical" style={{ width: '100%' }} size="large">
-          <Text style={{ color: '#fff' }}>
+          <Text style={{ color: UI_TEXT_PRIMARY_ON_DARK }}>
             Enter a name for your pose. This will save the current position of all {joints.length} joints.
             <br />
-            <Text style={{ color: '#888', fontSize: '12px' }}>
+            <Text style={{ color: UI_TEXT_SUBTLE, fontSize: '12px' }}>
               You can save multiple poses with different names. Duplicate names will automatically get a number suffix.
             </Text>
           </Text>
@@ -196,14 +209,14 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
             maxLength={50}
             autoFocus
             style={{
-              backgroundColor: '#1a1a1a',
-              borderColor: '#444',
-              color: '#fff'
+              backgroundColor: UI_INPUT_SURFACE,
+              borderColor: UI_BORDER_SOFT,
+              color: UI_TEXT_PRIMARY_ON_DARK
             }}
           />
 
           <div>
-            <Text style={{ color: '#888', fontSize: '12px', marginBottom: 8, display: 'block' }}>
+            <Text style={{ color: UI_TEXT_SUBTLE, fontSize: '12px', marginBottom: 8, display: 'block' }}>
               Quick suggestions:
             </Text>
             <Space wrap>
@@ -214,9 +227,9 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
                   type="dashed"
                   onClick={() => setPoseName(preset)}
                   style={{
-                    borderColor: '#444',
-                    color: '#888',
-                    backgroundColor: 'transparent'
+                    borderColor: UI_BORDER_SOFT,
+                    color: UI_TEXT_SUBTLE,
+                    backgroundColor: UI_COLOR_TRANSPARENT
                   }}
                 >
                   {preset}
@@ -225,13 +238,15 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
             </Space>
           </div>
 
-          <Card size="small" style={{ backgroundColor: '#0a0a0a', borderColor: '#333' }}>
+          <Card size="small" style={{ backgroundColor: UI_PANEL_BG, borderColor: UI_BORDER_MUTED }}>
             <Row gutter={16}>
               <Col span={12}>
-                <Text strong style={{ color: '#fff' }}>Joints to save:</Text> <Text style={{ color: '#00ff41' }}>{joints.length}</Text>
+                <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK }}>Joints to save:</Text>{' '}
+                <Text style={{ color: UI_ACCENT_GREEN }}>{joints.length}</Text>
               </Col>
               <Col span={12}>
-                <Text strong style={{ color: '#fff' }}>Timestamp:</Text> <Text style={{ color: '#00ff41' }}>{formatTimestamp(Date.now())}</Text>
+                <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK }}>Timestamp:</Text>{' '}
+                <Text style={{ color: UI_ACCENT_GREEN }}>{formatTimestamp(Date.now())}</Text>
               </Col>
             </Row>
           </Card>
@@ -241,7 +256,7 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
       {/* Load Pose Modal */}
       <Modal
         title={
-          <Title level={4} style={{ color: '#00ff41', margin: 0 }}>
+          <Title level={4} style={{ color: UI_ACCENT_GREEN, margin: 0 }}>
             <FolderOpenOutlined /> Load Saved Pose
           </Title>
         }
@@ -251,9 +266,9 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
             key="close"
             onClick={() => setLoadModalVisible(false)}
             style={{
-              backgroundColor: 'transparent',
-              borderColor: '#444',
-              color: '#fff'
+              backgroundColor: UI_COLOR_TRANSPARENT,
+              borderColor: UI_BORDER_SOFT,
+              color: UI_TEXT_PRIMARY_ON_DARK,
             }}
           >
             Close
@@ -263,13 +278,13 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
         width={700}
         style={{ top: 50 }}
         styles={{
-          mask: { backgroundColor: 'rgba(0, 0, 0, 0.8)' }
+          mask: { backgroundColor: UI_MODAL_MASK_BG }
         }}
         className="dark-modal"
       >
         {savedPoses.length === 0 ? (
-          <Card style={{ textAlign: 'center', backgroundColor: '#0a0a0a', borderColor: '#333' }}>
-            <Text style={{ color: '#888' }}>
+          <Card style={{ textAlign: 'center', backgroundColor: UI_PANEL_BG, borderColor: UI_BORDER_MUTED }}>
+            <Text style={{ color: UI_TEXT_SUBTLE }}>
               No saved poses found. Save your first pose to get started!
             </Text>
           </Card>
@@ -280,11 +295,11 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
               <List.Item
                 key={pose.id}
                 style={{
-                  backgroundColor: '#0c0c0c',
+                  backgroundColor: UI_LIST_ROW_BG,
                   marginBottom: 8,
                   borderRadius: 4,
                   padding: 12,
-                  border: '1px solid #333'
+                  border: `1px solid ${UI_BORDER_MUTED}`
                 }}
                 actions={[
                   <Tooltip title="Load this pose">
@@ -293,7 +308,7 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
                       icon={<DownloadOutlined />}
                       onClick={() => handleLoadPose(pose.id)}
                       loading={loading}
-                      style={{ backgroundColor: '#00ff41', borderColor: '#00ff41', color: '#000' }}
+                      style={{ ...UI_PRIMARY_GREEN_BUTTON_STYLE }}
                     >
                       Load
                     </Button>
@@ -318,17 +333,17 @@ export const PoseManager: React.FC<PoseManagerProps> = ({ joints, onLoadPose }) 
               >
                 <List.Item.Meta
                   title={
-                    <Text strong style={{ fontSize: 16, color: '#00ff41' }}>
+                    <Text strong style={{ fontSize: 16, color: UI_ACCENT_GREEN }}>
                       {pose.name}
                     </Text>
                   }
                   description={
                     <Space direction="vertical" size="small">
                       <Space>
-                        <ClockCircleOutlined style={{ color: '#888' }} />
-                        <Text style={{ color: '#888' }}>{formatTimestamp(pose.timestamp)}</Text>
+                        <ClockCircleOutlined style={{ color: UI_TEXT_SUBTLE }} />
+                        <Text style={{ color: UI_TEXT_SUBTLE }}>{formatTimestamp(pose.timestamp)}</Text>
                       </Space>
-                      <Text style={{ color: '#888' }}>
+                      <Text style={{ color: UI_TEXT_SUBTLE }}>
                         {getJointCount(pose.joints)} joints stored
                       </Text>
                     </Space>

--- a/src/Components/StreamMetrics.tsx
+++ b/src/Components/StreamMetrics.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UI_TEXT_SECONDARY_MUTED } from '../Constants/uiTheme.ts';
 
 interface StreamMetricsProps {
     fps: number;
@@ -16,16 +17,16 @@ export const StreamMetrics: React.FC<StreamMetricsProps> = ({
     return (
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             <span style={{ 
-                color: '#666', 
+                color: UI_TEXT_SECONDARY_MUTED, 
                 fontFamily: 'monospace', 
                 fontSize,
                 fontWeight: 'bold'
             }}>
                 {fps > 0 ? `${fps}${showLabels ? ' FPS' : ''}` : `--${showLabels ? ' FPS' : ''}`}
             </span>
-            <span style={{ color: '#666', fontSize: fontSize - 1 }}>|</span>
+            <span style={{ color: UI_TEXT_SECONDARY_MUTED, fontSize: fontSize - 1 }}>|</span>
             <span style={{ 
-                color: '#666', 
+                color: UI_TEXT_SECONDARY_MUTED, 
                 fontFamily: 'monospace', 
                 fontSize,
                 fontWeight: 'bold'

--- a/src/Components/StreamPlayerModal.tsx
+++ b/src/Components/StreamPlayerModal.tsx
@@ -5,22 +5,28 @@ import { StreamMetrics } from "./StreamMetrics.tsx";
 import { MovableModal } from './MovableModal.tsx';
 import { STREAM_SOURCES, DEFAULT_STREAM_SOURCE } from '../Constants/rosConfig';
 import type { StreamSource } from '../Constants/rosConfig';
+import {
+    UI_ACCENT_ORANGE,
+    UI_BORDER_MUTED,
+    UI_CHROME_SURFACE,
+    UI_INPUT_SURFACE,
+} from '../Constants/uiTheme.ts';
 
 const WARNING_BADGE_STYLE: React.CSSProperties = {
-    color: '#ffa500',
+    color: UI_ACCENT_ORANGE,
     fontFamily: 'monospace',
     fontSize: 10,
     padding: '2px 6px',
-    backgroundColor: '#1a1a1a',
-    border: '1px solid #ffa500',
+    backgroundColor: UI_INPUT_SURFACE,
+    border: `1px solid ${UI_ACCENT_ORANGE}`,
     borderRadius: 4
 };
 
 const SELECT_POPUP_STYLE = {
     popup: {
         root: {
-            backgroundColor: '#0d0d0d',
-            borderColor: '#333',
+            backgroundColor: UI_CHROME_SURFACE,
+            borderColor: UI_BORDER_MUTED,
         }
     }
 };

--- a/src/Components/ToggleSwitch.tsx
+++ b/src/Components/ToggleSwitch.tsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import {
+    UI_ACCENT_GREEN,
+    UI_CHROME_SURFACE,
+    UI_TEXT_ON_ACCENT,
+    UI_TOGGLE_TRACK_BORDER,
+} from '../Constants/uiTheme.ts';
 
 export interface ToggleSwitchProps {
     isOn: boolean;
@@ -28,7 +34,7 @@ export const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
             <span style={{
                 fontFamily: 'monospace',
                 fontSize: 11,
-                color: '#00ff41',
+                color: UI_ACCENT_GREEN,
                 letterSpacing: 0.5,
                 textTransform: 'uppercase',
                 opacity: 0.8
@@ -48,12 +54,12 @@ export const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
                     position: 'relative',
                     padding: 2,
                     borderRadius: 18,
-                    backgroundColor: '#0d0d0d',
-                    border: '1px solid #2a2a2a',
+                    backgroundColor: UI_CHROME_SURFACE,
+                    border: `1px solid ${UI_TOGGLE_TRACK_BORDER}`,
                     cursor: 'pointer',
                     userSelect: 'none',
                     outline: 'none',
-                    color: '#00ff41',
+                    color: UI_ACCENT_GREEN,
                 }}
             >
                 <div
@@ -64,8 +70,8 @@ export const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
                         width: `calc(50% - 4px)`,
                         height: `calc(100% - 4px)`,
                         borderRadius: 16,
-                        backgroundColor: '#00ff41',
-                        boxShadow: isOn ? '0 0 12px #00ff41' : 'none',
+                        backgroundColor: UI_ACCENT_GREEN,
+                        boxShadow: isOn ? `0 0 12px ${UI_ACCENT_GREEN}` : 'none',
                         transition: 'left 160ms ease, box-shadow 160ms ease',
                     }}
                 />
@@ -82,7 +88,7 @@ export const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
                         fontWeight: 600,
                         letterSpacing: 0.5,
                         zIndex: 1,
-                        color: isOn ? '#00ff41' : '#000',
+                        color: isOn ? UI_ACCENT_GREEN : UI_TEXT_ON_ACCENT,
                         opacity: isOn ? 0.9 : 1,
                     }}
                 >
@@ -102,7 +108,7 @@ export const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
                         fontWeight: 600,
                         letterSpacing: 0.5,
                         zIndex: 1,
-                        color: isOn ? '#000' : '#00ff41',
+                        color: isOn ? UI_TEXT_ON_ACCENT : UI_ACCENT_GREEN,
                     }}
                 >
                     {rightIcon}

--- a/src/Constants/hardwareConfigRos.ts
+++ b/src/Constants/hardwareConfigRos.ts
@@ -2,6 +2,11 @@
 
 export type HardwareConfigServiceSuffix = 'get' | 'save' | 'list' | 'activate' | 'delete';
 
+/** ROS 2 action interface string as exposed by rosbridge / roslib. */
+export const CONFIGURE_PIPELINE_ACTION_INTERFACE = 'lucy_msgs/action/ConfigurePipeline';
+/** Matches `configure_pipeline` endpoint advertised by lucy_config_pipeline. */
+export const CONFIGURE_PIPELINE_SERVER_NAME = '/configure_pipeline';
+
 export function hardwareConfigServiceUri(which: HardwareConfigServiceSuffix): string {
     return `/config/${which}`;
 }

--- a/src/Constants/hardwareConfigTypes.ts
+++ b/src/Constants/hardwareConfigTypes.ts
@@ -10,8 +10,13 @@ export interface StructuredValidationLine {
 export interface GetConfigResponse {
     success: boolean;
     message: string;
+    robot_package: string;
     config_name: string;
     config_yaml: string;
+    /** Preset last successfully flashed (from active_meta.yaml); empty if none. */
+    flashed_config_name: string;
+    /** ISO-8601 UTC from server; empty if none. */
+    flashed_at: string;
 }
 
 export interface SaveConfigResponse {
@@ -37,4 +42,30 @@ export interface ActivateConfigResponse {
 export interface DeleteConfigResponse {
     success: boolean;
     message: string;
+}
+
+/** Goal fields mirrored from `lucy_msgs/action/ConfigurePipeline.action`. */
+export interface ConfigurePipelineGoalInput {
+    robot_package: string;
+    /** Named config slot or empty → active YAML on the robot. */
+    mapping_file: string;
+    /** Empty array → process all boards (`lucy_config_pipeline` semantics). */
+    boards_to_flash: string[];
+    dry_run: boolean;
+    build_only: boolean;
+}
+
+export interface ConfigurePipelineFeedbackNormalized {
+    phase: string;
+    board: string;
+    progress: number;
+    detail: string;
+}
+
+export interface ConfigurePipelineResultNormalized {
+    success: boolean;
+    message: string;
+    config_name: string;
+    boards_flashed: string[];
+    errors: string[];
 }

--- a/src/Constants/uiTheme.ts
+++ b/src/Constants/uiTheme.ts
@@ -1,42 +1,105 @@
-/** Shared terminal / Lucy panel palette (hex). */
+/**
+ * Single palette for the Lucy control panel — prefer importing from here instead of raw hex/rgb.
+ * CSS files that cannot import TS use `var(--ui-*)` values applied via {@link mountUiThemeCssVars}.
+ */
 
 export const UI_ACCENT_GREEN = '#00ff41';
-/** Matches `UI_ACCENT_GREEN` (#00ff41) for `rgba(...)` in global CSS. */
+/** Matches `UI_ACCENT_GREEN` for `rgba(...)` in global CSS. */
 export const UI_ACCENT_RGB = '0, 255, 65';
 
 export function uiAccentRgba(alpha: number): string {
     return `rgba(${UI_ACCENT_RGB}, ${alpha})`;
 }
 
+/** Matches `UI_ERROR_RED` (#ff4d4f) for rgba overlays. */
+export const UI_ERROR_RGB = '255, 77, 79';
+
+export function uiErrorRgba(alpha: number): string {
+    return `rgba(${UI_ERROR_RGB}, ${alpha})`;
+}
+
 export const UI_PANEL_BG = '#0a0a0a';
 export const UI_BG_BLACK = '#000000';
-/** Inputs and inset surfaces */
 export const UI_INPUT_SURFACE = '#1a1a1a';
-/** Divider and card borders */
-export const UI_BORDER_MUTED = '#333';
-/** Ant Design token parity (`#333333`) */
+export const UI_BORDER_MUTED = '#333333';
 export const UI_BORDER_STRONG = '#333333';
-export const UI_BORDER_SOFT = '#444';
-export const UI_TEXT_ON_ACCENT = '#000';
+export const UI_BORDER_SOFT = '#444444';
+export const UI_BORDER_DIM = '#222222';
+export const UI_TEXT_ON_ACCENT = '#000000';
 export const UI_TEXT_PRIMARY_ON_DARK = '#ffffff';
 export const UI_TEXT_SECONDARY_MUTED = '#666666';
+/** Muted labels / secondary lines (Ant `colorTextSecondary` parity). */
+export const UI_TEXT_SUBTLE = '#888888';
 export const UI_ERROR_RED = '#ff4d4f';
 export const UI_WARNING_AMBER = '#faad14';
+/** Connecting / highlight orange (ROS bridge, stream chrome). */
+export const UI_ACCENT_ORANGE = '#ffa500';
+/** Decorative accent on NotFound — not the primary semantic error color. */
+export const UI_DECORATIVE_CORAL = '#ff6b6b';
+
+export const UI_LIST_ROW_BG = '#0c0c0c';
+export const UI_CHROME_SURFACE = '#0d0d0d';
+export const UI_MODAL_SURFACE = '#0b0b0b';
+export const UI_MODAL_HEADER_TOP = '#121212';
+export const UI_TOGGLE_TRACK_BORDER = '#2a2a2a';
+
+/** Disabled hardware-config “add” buttons / switch track fallback. */
+export const UI_SWITCH_DISABLED_BG = '#555555';
+export const UI_SWITCH_DISABLED_BORDER = '#666666';
+
+export const UI_MODAL_MASK_BG = 'rgba(0, 0, 0, 0.8)';
+export const UI_NAV_BAR_BG = 'rgba(10, 10, 10, 0.9)';
+export const UI_OVERLAY_BACKDROP_SOFT = 'rgba(0, 0, 0, 0.6)';
+export const UI_SHADOW_ELEVATED = '0 8px 24px rgba(0, 0, 0, 0.6)';
+
+export const UI_COLOR_TRANSPARENT = 'transparent';
+
+/** Mediapipe / canvas drawing (distinct from UI accent for visibility). */
+export const UI_CANVAS_LIME = '#00ff00';
+export const UI_CANVAS_RED = '#ff0000';
+/** Index fingertip marker on hand-tracking canvas. */
+export const UI_VIDEO_OVERLAY_CYAN = '#00ffff';
+
+/** Auth card alert tint (invalid credentials). */
+export const UI_AUTH_ALERT_SURFACE = '#1a0a0a';
+
+/** Ant Design `Tag` presets */
+export const UI_TAG_ACTIVE_PRESET = 'cyan' as const;
+export const UI_TAG_TARGET_PRESET = 'orange' as const;
+export const UI_TAG_FLASHED_PRESET = 'purple' as const;
+export const UI_TAG_LOADED_PRESET = 'blue' as const;
 
 export const UI_ACCENT_TEXT_SHADOW = `0 0 10px ${UI_ACCENT_GREEN}`;
 export const UI_ACCENT_BOX_SHADOW_SOFT = `0 0 8px ${UI_ACCENT_GREEN}`;
 export const UI_ACCENT_BOX_SHADOW_STRONG = `0 0 10px ${UI_ACCENT_GREEN}`;
 export const UI_PAGE_HEADER_BORDER_BOTTOM = `2px solid ${UI_BORDER_MUTED}`;
 
-/** Dark inset panels (Cards, modals). */
 export const UI_CARD_SURFACE_STYLE = {
     background: UI_PANEL_BG,
     borderColor: UI_BORDER_MUTED,
 } as const;
 
-/** Primary “terminal green” action button (dark bg apps). */
 export const UI_PRIMARY_GREEN_BUTTON_STYLE = {
     backgroundColor: UI_ACCENT_GREEN,
     borderColor: UI_ACCENT_GREEN,
     color: UI_TEXT_ON_ACCENT,
 } as const;
+
+export const UI_GRADIENT_AUTH_PAGE = `linear-gradient(135deg, ${UI_BG_BLACK} 0%, ${UI_PANEL_BG} 100%)`;
+export const UI_GRADIENT_MODAL_HEADER = `linear-gradient(180deg, ${UI_MODAL_HEADER_TOP}, ${UI_MODAL_SURFACE})`;
+
+const UI_THEME_CSS_VARS: Record<string, string> = {
+    '--ui-accent-green': UI_ACCENT_GREEN,
+    '--ui-text-on-accent': UI_TEXT_ON_ACCENT,
+    '--ui-switch-disabled-bg': UI_SWITCH_DISABLED_BG,
+    '--ui-switch-disabled-border': UI_SWITCH_DISABLED_BORDER,
+};
+
+/** Call once at startup so `.css` files can use `var(--ui-*)`. */
+export function mountUiThemeCssVars(): void {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    for (const [key, value] of Object.entries(UI_THEME_CSS_VARS)) {
+        root.style.setProperty(key, value);
+    }
+}

--- a/src/Pages/NotFound.tsx
+++ b/src/Pages/NotFound.tsx
@@ -3,6 +3,19 @@ import { Typography, Button, Space } from 'antd';
 import { HomeOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import { Page } from '../Components/Page';
+import {
+    UI_ACCENT_GREEN,
+    UI_BORDER_MUTED,
+    UI_BORDER_SOFT,
+    UI_COLOR_TRANSPARENT,
+    UI_DECORATIVE_CORAL,
+    UI_ERROR_RED,
+    UI_INPUT_SURFACE,
+    UI_PANEL_BG,
+    UI_TEXT_ON_ACCENT,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SECONDARY_MUTED,
+} from '../Constants/uiTheme.ts';
 
 const { Text } = Typography;
 
@@ -98,11 +111,11 @@ export const NotFound: React.FC = () => {
         <div style={{ marginBottom: '20px' }}>
           <Text
             style={{
-              color: '#ff4d4f',
+              color: UI_ERROR_RED,
               fontFamily: 'monospace',
               fontSize: '24px',
               fontWeight: 'bold',
-              textShadow: '0 0 15px #ff4d4f',
+              textShadow: `0 0 15px ${UI_ERROR_RED}`,
               display: 'block',
               marginBottom: '10px'
             }}
@@ -112,7 +125,7 @@ export const NotFound: React.FC = () => {
 
           <Text
             style={{
-              color: '#00ff41',
+              color: UI_ACCENT_GREEN,
               fontFamily: 'monospace',
               fontSize: '14px',
               display: 'block'
@@ -131,8 +144,8 @@ export const NotFound: React.FC = () => {
         {/* ASCII Art */}
         <div
           style={{
-            backgroundColor: '#0a0a0a',
-            border: '2px solid #333',
+            backgroundColor: UI_PANEL_BG,
+            border: `2px solid ${UI_BORDER_MUTED}`,
             padding: '20px',
             marginBottom: '20px',
             maxWidth: '600px',
@@ -141,7 +154,7 @@ export const NotFound: React.FC = () => {
         >
           <pre
             style={{
-              color: '#00ff41',
+              color: UI_ACCENT_GREEN,
               fontFamily: 'monospace',
               fontSize: '12px',
               lineHeight: '1.2',
@@ -157,8 +170,8 @@ export const NotFound: React.FC = () => {
         {/* Glitch Effect Error Messages */}
         <div
           style={{
-            backgroundColor: '#1a1a1a',
-            border: '1px solid #444',
+            backgroundColor: UI_INPUT_SURFACE,
+            border: `1px solid ${UI_BORDER_SOFT}`,
             padding: '16px',
             marginBottom: '20px',
             minHeight: '50px',
@@ -171,7 +184,7 @@ export const NotFound: React.FC = () => {
         >
           <Text
             style={{
-              color: '#ff6b6b',
+              color: UI_DECORATIVE_CORAL,
               fontFamily: 'monospace',
               fontSize: '13px',
               fontStyle: 'italic',
@@ -194,31 +207,31 @@ export const NotFound: React.FC = () => {
           }}
         >
           <div style={{
-            backgroundColor: '#1a1a1a',
-            border: '1px solid #444',
+            backgroundColor: UI_INPUT_SURFACE,
+            border: `1px solid ${UI_BORDER_SOFT}`,
             padding: '12px',
             textAlign: 'center'
           }}>
-            <Text style={{ color: '#666', fontSize: '10px', display: 'block' }}>STATUS</Text>
-            <Text style={{ color: '#ff4d4f', fontFamily: 'monospace', fontSize: '14px' }}>LOST</Text>
+            <Text style={{ color: UI_TEXT_SECONDARY_MUTED, fontSize: '10px', display: 'block' }}>STATUS</Text>
+            <Text style={{ color: UI_ERROR_RED, fontFamily: 'monospace', fontSize: '14px' }}>LOST</Text>
           </div>
           <div style={{
-            backgroundColor: '#1a1a1a',
-            border: '1px solid #444',
+            backgroundColor: UI_INPUT_SURFACE,
+            border: `1px solid ${UI_BORDER_SOFT}`,
             padding: '12px',
             textAlign: 'center'
           }}>
-            <Text style={{ color: '#666', fontSize: '10px', display: 'block' }}>CODE</Text>
-            <Text style={{ color: '#ff4d4f', fontFamily: 'monospace', fontSize: '14px' }}>404</Text>
+            <Text style={{ color: UI_TEXT_SECONDARY_MUTED, fontSize: '10px', display: 'block' }}>CODE</Text>
+            <Text style={{ color: UI_ERROR_RED, fontFamily: 'monospace', fontSize: '14px' }}>404</Text>
           </div>
           <div style={{
-            backgroundColor: '#1a1a1a',
-            border: '1px solid #444',
+            backgroundColor: UI_INPUT_SURFACE,
+            border: `1px solid ${UI_BORDER_SOFT}`,
             padding: '12px',
             textAlign: 'center'
           }}>
-            <Text style={{ color: '#666', fontSize: '10px', display: 'block' }}>HOPE</Text>
-            <Text style={{ color: '#00ff41', fontFamily: 'monospace', fontSize: '14px' }}>HIGH</Text>
+            <Text style={{ color: UI_TEXT_SECONDARY_MUTED, fontSize: '10px', display: 'block' }}>HOPE</Text>
+            <Text style={{ color: UI_ACCENT_GREEN, fontFamily: 'monospace', fontSize: '14px' }}>HIGH</Text>
           </div>
         </div>
 
@@ -230,9 +243,9 @@ export const NotFound: React.FC = () => {
             onClick={handleGoHome}
             size="large"
             style={{
-              backgroundColor: '#00ff41',
-              borderColor: '#00ff41',
-              color: '#000',
+              backgroundColor: UI_ACCENT_GREEN,
+              borderColor: UI_ACCENT_GREEN,
+              color: UI_TEXT_ON_ACCENT,
               fontWeight: 'bold',
               fontFamily: 'monospace',
               padding: '8px 24px',
@@ -247,9 +260,9 @@ export const NotFound: React.FC = () => {
             onClick={handleReload}
             size="large"
             style={{
-              backgroundColor: 'transparent',
-              borderColor: '#444',
-              color: '#fff',
+              backgroundColor: UI_COLOR_TRANSPARENT,
+              borderColor: UI_BORDER_SOFT,
+              color: UI_TEXT_PRIMARY_ON_DARK,
               fontFamily: 'monospace',
               padding: '8px 24px',
               height: 'auto'
@@ -263,7 +276,7 @@ export const NotFound: React.FC = () => {
         <div style={{ marginTop: '30px', maxWidth: '500px' }}>
           <Text
             style={{
-              color: '#666',
+              color: UI_TEXT_SECONDARY_MUTED,
               fontFamily: 'monospace',
               fontSize: '11px',
               lineHeight: '1.5',
@@ -274,7 +287,7 @@ export const NotFound: React.FC = () => {
             <br />
             Lucy is probably just recalibrating its navigation systems.
             <br />
-            <span style={{ color: '#00ff41' }}>
+            <span style={{ color: UI_ACCENT_GREEN }}>
               ► Press RETURN HOME to get back on track ◄
             </span>
           </Text>

--- a/src/Pages/Robot3DViewer.tsx
+++ b/src/Pages/Robot3DViewer.tsx
@@ -8,6 +8,13 @@ import {isWebGLAvailable, STLLoader} from 'three-stdlib';
 import * as THREE from 'three';
 // import { RobotPathResolver } from '../Constants/robotConfig';
 import { Page } from '../Components/Page';
+import {
+    UI_ACCENT_GREEN,
+    UI_BG_BLACK,
+    UI_BORDER_MUTED,
+    UI_MODAL_MASK_BG,
+    UI_TEXT_PRIMARY_ON_DARK,
+} from '../Constants/uiTheme.ts';
 
 const { Text } = Typography;
 
@@ -35,7 +42,7 @@ const STLMesh: React.FC<STLMeshProps> = ({ meshData, opacity, wireframe }) => {
         >
             <meshStandardMaterial
                 key={`${wireframe}-${opacity}`}
-                color="#00ff41"
+                color={UI_ACCENT_GREEN}
                 transparent
                 opacity={opacity}
                 wireframe={wireframe}
@@ -180,7 +187,9 @@ const Robot3DViewer: React.FC = () => {
         return (
             <Page contentStyle={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                 <Spin size="large" />
-                <Text style={{ color: '#fff', marginLeft: 16 }}>Loading 3D robot model...</Text>
+                <Text style={{ color: UI_TEXT_PRIMARY_ON_DARK, marginLeft: 16 }}>
+                    Loading 3D robot model...
+                </Text>
             </Page>
         );
     }
@@ -206,7 +215,7 @@ const Robot3DViewer: React.FC = () => {
   const headerContent = (
     <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', width: '100%' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-        <Text style={{ color: '#fff', fontFamily: 'monospace' }}>WIREFRAME:</Text>
+        <Text style={{ color: UI_TEXT_PRIMARY_ON_DARK, fontFamily: 'monospace' }}>WIREFRAME:</Text>
         <div className="tui-toggle">
           <button
             onClick={() => setWireframe(false)}
@@ -223,7 +232,7 @@ const Robot3DViewer: React.FC = () => {
           </button>
         </div>
 
-        <Text style={{ color: '#fff', fontFamily: 'monospace' }}>GRID:</Text>
+        <Text style={{ color: UI_TEXT_PRIMARY_ON_DARK, fontFamily: 'monospace' }}>GRID:</Text>
         <div className="tui-toggle">
           <button
             onClick={() => setShowGrid(false)}
@@ -257,7 +266,7 @@ const Robot3DViewer: React.FC = () => {
             near: 0.1,
             far: 1000
           }}
-          style={{ background: '#000' }}
+          style={{ background: UI_BG_BLACK }}
         >
           <ambientLight intensity={0.6} />
           <directionalLight
@@ -266,17 +275,17 @@ const Robot3DViewer: React.FC = () => {
             castShadow
             shadow-mapSize={[2048, 2048]}
           />
-          <pointLight position={[-10, -10, -5]} intensity={0.5} color="#00ff41" />
+          <pointLight position={[-10, -10, -5]} intensity={0.5} color={UI_ACCENT_GREEN} />
 
           {showGrid && (
             <Grid
               args={[20, 20]}
               cellSize={1}
               cellThickness={0.5}
-              cellColor="#00ff41"
+              cellColor={UI_ACCENT_GREEN}
               sectionSize={5}
               sectionThickness={1}
-              sectionColor="#ffffff"
+              sectionColor={UI_TEXT_PRIMARY_ON_DARK}
               fadeDistance={30}
               fadeStrength={1}
             />
@@ -303,22 +312,22 @@ const Robot3DViewer: React.FC = () => {
             position: 'absolute',
             top: 16,
             left: 16,
-            backgroundColor: 'rgba(0, 0, 0, 0.8)',
-            border: '1px solid #333',
+            backgroundColor: UI_MODAL_MASK_BG,
+            border: `1px solid ${UI_BORDER_MUTED}`,
             padding: 16,
             fontFamily: 'monospace',
-            color: '#fff',
+            color: UI_TEXT_PRIMARY_ON_DARK,
             fontSize: '12px'
           }}
         >
           <div style={{ marginBottom: 8 }}>
-            <Text style={{ color: '#00ff41' }}>CONTROLS:</Text>
+            <Text style={{ color: UI_ACCENT_GREEN }}>CONTROLS:</Text>
           </div>
           <div>• Mouse: Rotate view</div>
           <div>• Wheel: Zoom in/out</div>
           <div>• Right click + drag: Pan</div>
           <div style={{ marginTop: 8 }}>
-            <Text style={{ color: '#00ff41' }}>MESHES LOADED: {meshes.length}</Text>
+            <Text style={{ color: UI_ACCENT_GREEN }}>MESHES LOADED: {meshes.length}</Text>
           </div>
         </div>
 
@@ -328,16 +337,16 @@ const Robot3DViewer: React.FC = () => {
             position: 'absolute',
             bottom: 16,
             left: 16,
-            backgroundColor: 'rgba(0, 0, 0, 0.8)',
-            border: '1px solid #333',
+            backgroundColor: UI_MODAL_MASK_BG,
+            border: `1px solid ${UI_BORDER_MUTED}`,
             padding: 16,
             fontFamily: 'monospace',
-            color: '#fff',
+            color: UI_TEXT_PRIMARY_ON_DARK,
             fontSize: '12px',
             minWidth: 200
           }}
         >
-          <Text style={{ color: '#00ff41', marginBottom: 8, display: 'block' }}>
+          <Text style={{ color: UI_ACCENT_GREEN, marginBottom: 8, display: 'block' }}>
             TRANSPARENCY: {Math.round(opacity * 100)}%
           </Text>
           <input
@@ -349,7 +358,7 @@ const Robot3DViewer: React.FC = () => {
             onChange={(e) => setOpacity(parseFloat(e.target.value))}
             style={{
               width: '100%',
-              background: '#333',
+              background: UI_BORDER_MUTED,
               outline: 'none',
               height: '4px',
               borderRadius: '0'

--- a/src/Pages/RobotControlPanel.tsx
+++ b/src/Pages/RobotControlPanel.tsx
@@ -53,7 +53,14 @@ import { StreamPlayerModal } from "../Components/StreamPlayerModal";
 import { MovableModal } from '../Components/MovableModal';
 import { ControlPanelHeaderStats, LucyControlPanelHeader } from '../Components/LucyControlPanelHeader.tsx';
 import type { ControllerJointConfig } from '../Constants/rosConfig';
-import { UI_ACCENT_BOX_SHADOW_STRONG, UI_ACCENT_GREEN, UI_BORDER_SOFT } from '../Constants/uiTheme.ts';
+import {
+    UI_ACCENT_BOX_SHADOW_STRONG,
+    UI_ACCENT_GREEN,
+    UI_BORDER_SOFT,
+    UI_COLOR_TRANSPARENT,
+    UI_TEXT_ON_ACCENT,
+    UI_TEXT_PRIMARY_ON_DARK,
+} from '../Constants/uiTheme.ts';
 
 const MediapipeHandTracker = lazy(() => import('../Components/MediapipeHandTracker').then(module => ({ default: module.default })));
 
@@ -276,7 +283,9 @@ export const RobotControlPanel: React.FC = () => {
         return (
             <Page contentStyle={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
                 <Spin size="large" />
-                <Text style={{ color: '#fff', marginLeft: 16 }}>Loading robot configuration...</Text>
+                <Text style={{ color: UI_TEXT_PRIMARY_ON_DARK, marginLeft: 16 }}>
+                    Loading robot configuration...
+                </Text>
             </Page>
         );
     }
@@ -338,9 +347,9 @@ export const RobotControlPanel: React.FC = () => {
                                     icon={<ReloadOutlined />}
                                     onClick={handleResetAll}
                                     style={{
-                                        backgroundColor: 'transparent',
-                                        borderColor: '#444',
-                                        color: '#fff',
+                                        backgroundColor: UI_COLOR_TRANSPARENT,
+                                        borderColor: UI_BORDER_SOFT,
+                                        color: UI_TEXT_PRIMARY_ON_DARK,
                                     }}
                                 >
                                     RESET ALL
@@ -353,8 +362,8 @@ export const RobotControlPanel: React.FC = () => {
                                 <Button
                                     onClick={() => setIsStreamVisible(v => !v)}
                                     style={{
-                                        backgroundColor: isStreamVisible ? UI_ACCENT_GREEN : 'transparent',
-                                        color: isStreamVisible ? '#000' : '#fff',
+                                        backgroundColor: isStreamVisible ? UI_ACCENT_GREEN : UI_COLOR_TRANSPARENT,
+                                        color: isStreamVisible ? UI_TEXT_ON_ACCENT : UI_TEXT_PRIMARY_ON_DARK,
                                         borderColor: isStreamVisible ? UI_ACCENT_GREEN : UI_BORDER_SOFT,
                                         boxShadow: isStreamVisible ? UI_ACCENT_BOX_SHADOW_STRONG : 'none',
                                     }}
@@ -364,8 +373,8 @@ export const RobotControlPanel: React.FC = () => {
                                 <Button
                                     onClick={() => setIsWebcamActive(v => !v)}
                                     style={{
-                                        backgroundColor: isWebcamActive ? UI_ACCENT_GREEN : 'transparent',
-                                        color: isWebcamActive ? '#000' : '#fff',
+                                        backgroundColor: isWebcamActive ? UI_ACCENT_GREEN : UI_COLOR_TRANSPARENT,
+                                        color: isWebcamActive ? UI_TEXT_ON_ACCENT : UI_TEXT_PRIMARY_ON_DARK,
                                         borderColor: isWebcamActive ? UI_ACCENT_GREEN : UI_BORDER_SOFT,
                                         boxShadow: isWebcamActive ? UI_ACCENT_BOX_SHADOW_STRONG : 'none',
                                     }}

--- a/src/Pages/Stream.tsx
+++ b/src/Pages/Stream.tsx
@@ -5,25 +5,33 @@ import { StreamPlayer } from '../Components/StreamPlayer';
 import { StreamMetrics } from '../Components/StreamMetrics';
 import type { StreamSource } from '../Constants/rosConfig';
 import { STREAM_SOURCES, DEFAULT_STREAM_SOURCE } from '../Constants/rosConfig';
+import {
+    UI_ACCENT_GREEN,
+    UI_ACCENT_ORANGE,
+    UI_ACCENT_TEXT_SHADOW,
+    UI_BORDER_MUTED,
+    UI_CHROME_SURFACE,
+    UI_INPUT_SURFACE,
+} from '../Constants/uiTheme.ts';
 
 const Text = Typography;
 
 const SELECT_POPUP_STYLE = {
     popup: {
         root: {
-            backgroundColor: '#0d0d0d',
-            borderColor: '#333',
+            backgroundColor: UI_CHROME_SURFACE,
+            borderColor: UI_BORDER_MUTED,
         }
     }
 };
 
 const WARNING_BADGE_STYLE: React.CSSProperties = {
-    color: '#ffa500',
+    color: UI_ACCENT_ORANGE,
     fontFamily: 'monospace',
     fontSize: 10,
     padding: '2px 6px',
-    backgroundColor: '#1a1a1a',
-    border: '1px solid #ffa500',
+    backgroundColor: UI_INPUT_SURFACE,
+    border: `1px solid ${UI_ACCENT_ORANGE}`,
     borderRadius: 4
 };
 
@@ -56,9 +64,9 @@ export const Stream: React.FC = () => {
                     <Text
                         style={{
                             margin: 0,
-                            color: '#00ff41',
+                            color: UI_ACCENT_GREEN,
                             fontFamily: 'monospace',
-                            textShadow: '0 0 10px #00ff41',
+                            textShadow: UI_ACCENT_TEXT_SHADOW,
                             fontSize: '18px',
                             fontWeight: 'bold',
                         }}

--- a/src/Services/ros/handlers/ConfigurePipeline.handler.ts
+++ b/src/Services/ros/handlers/ConfigurePipeline.handler.ts
@@ -1,0 +1,256 @@
+/**
+ * ROS transport only: streams `ConfigurePipeline` action feedback/results from
+ * `lucy_config_pipeline` through rosbridge.
+ *
+ * Uses rosbridge ROS 2 `send_action_goal` / `action_feedback` / `action_result` ops.
+ * The stock `ROSLIB.ActionClient` is ROS 1–style (topics + `*Goal` message types) and
+ * does not match ROS 2 generated types (`lucy_msgs.action.ConfigurePipeline.Goal`).
+ */
+import ROSLIB from 'roslib';
+import {
+    CONFIGURE_PIPELINE_ACTION_INTERFACE,
+    CONFIGURE_PIPELINE_SERVER_NAME,
+} from '../../../Constants/hardwareConfigRos.ts';
+import type {
+    ConfigurePipelineFeedbackNormalized,
+    ConfigurePipelineGoalInput,
+    ConfigurePipelineResultNormalized,
+} from '../../../Constants/hardwareConfigTypes.ts';
+import { RosBridgeService } from '../ros.service.ts';
+
+const DEFAULT_GOAL_TIMEOUT_MS = 720_000; // firmware build + flash can be slow
+
+type RosWithConnection = ROSLIB.Ros & {
+    callOnConnection: (message: Record<string, unknown>) => void;
+};
+
+function getRos(): RosWithConnection | null {
+    const r = RosBridgeService.getInstance().rosConnection;
+    return r as RosWithConnection | null;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+    return v !== null && typeof v === 'object' && !Array.isArray(v)
+        ? (v as Record<string, unknown>)
+        : null;
+}
+
+export function normalizeConfigurePipelineFeedback(raw: unknown): ConfigurePipelineFeedbackNormalized {
+    const root = asRecord(raw);
+    const fromValues = root && 'values' in root ? asRecord(root.values) : null;
+    const o =
+        fromValues ??
+        (root && 'feedback' in root ? asRecord(root.feedback) ?? {} : root ?? {});
+    const phase = String(o.phase ?? '');
+    const board = String(o.board ?? '');
+    let detail = typeof o.detail === 'string' ? o.detail : '';
+    const pn = typeof o.progress === 'number' ? o.progress : Number(o.progress ?? 0);
+    const progress = Number.isFinite(pn) ? Math.min(1, Math.max(0, pn)) : 0;
+    const trimmed = detail.trim();
+    if (trimmed.startsWith('{')) {
+        try {
+            const j = JSON.parse(trimmed) as { message?: string };
+            if (typeof j?.message === 'string') detail = j.message;
+        } catch {
+            /* keep detail string */
+        }
+    }
+    return { phase, board, progress, detail };
+}
+
+export function normalizeConfigurePipelineResult(raw: unknown): ConfigurePipelineResultNormalized {
+    const root = asRecord(raw);
+    if (root && root.result === false) {
+        const errText = typeof root.values === 'string' ? root.values : 'ConfigurePipeline failed';
+        return {
+            success: false,
+            message: errText,
+            config_name: '',
+            boards_flashed: [],
+            errors: [errText],
+        };
+    }
+    const o =
+        root && typeof root.values === 'object' && root.values !== null
+            ? asRecord(root.values) ?? {}
+            : root && 'result' in root
+              ? asRecord(root.result) ?? {}
+              : root ?? {};
+    const errs = Array.isArray(o.errors) ? o.errors.filter((x): x is string => typeof x === 'string') : [];
+    const flashed = Array.isArray(o.boards_flashed)
+        ? o.boards_flashed.filter((x): x is string => typeof x === 'string')
+        : [];
+    return {
+        success: Boolean(o.success),
+        message: typeof o.message === 'string' ? o.message : '',
+        config_name: typeof o.config_name === 'string' ? o.config_name : '',
+        boards_flashed: flashed,
+        errors: errs,
+    };
+}
+
+export interface RunConfigurePipelineCallbacks {
+    onFeedback?: (f: ConfigurePipelineFeedbackNormalized) => void;
+}
+
+export interface ConfigurePipelineRunHandle {
+    promise: Promise<ConfigurePipelineResultNormalized>;
+    abort: () => void;
+}
+
+type WebSocketWithPrev = WebSocket & { __lucyPrevOnMessage?: ((ev: MessageEvent) => void) | null };
+
+/** Rosbridge JSON ops are not forwarded by roslib's SocketAdapter; tap the socket after roslib runs. */
+function tapRosbridgeJson(
+    ros: RosWithConnection,
+    onJson: (msg: Record<string, unknown>) => void,
+): () => void {
+    const sock = (ros as unknown as { socket?: WebSocket }).socket;
+    if (!sock) {
+        return () => {};
+    }
+    const ws = sock as WebSocketWithPrev;
+    const prev = ws.onmessage;
+    ws.__lucyPrevOnMessage = prev ?? null;
+    ws.onmessage = (event: MessageEvent) => {
+        if (typeof prev === 'function') {
+            try {
+                prev.call(ws, event);
+            } catch {
+                /* roslib */
+            }
+        }
+        try {
+            const text = typeof event.data === 'string' ? event.data : '';
+            if (!text) return;
+            const msg = JSON.parse(text) as Record<string, unknown>;
+            onJson(msg);
+        } catch {
+            /* non-JSON / binary */
+        }
+    };
+    return () => {
+        ws.onmessage = ws.__lucyPrevOnMessage ?? prev;
+        delete ws.__lucyPrevOnMessage;
+    };
+}
+
+let configurePipelineRunLock = false;
+
+/**
+ * Sends one action goal and resolves when `action_result` is received; rejects on timeout or disconnect.
+ */
+export function startConfigurePipeline(
+    input: ConfigurePipelineGoalInput,
+    callbacks?: RunConfigurePipelineCallbacks,
+    timeoutMs: number = DEFAULT_GOAL_TIMEOUT_MS,
+): ConfigurePipelineRunHandle {
+    const ros = getRos();
+    if (!ros) {
+        return {
+            promise: Promise.reject(new Error('ROS bridge is not connected.')),
+            abort: () => {},
+        };
+    }
+
+    if (configurePipelineRunLock) {
+        return {
+            promise: Promise.reject(new Error('ConfigurePipeline is already running.')),
+            abort: () => {},
+        };
+    }
+
+    const goalId = `configure_pipeline_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    const action = CONFIGURE_PIPELINE_SERVER_NAME;
+    const actionType = CONFIGURE_PIPELINE_ACTION_INTERFACE;
+
+    const args: Record<string, unknown> = {
+        robot_package: input.robot_package,
+        mapping_file: input.mapping_file,
+        boards_to_flash: input.boards_to_flash,
+        dry_run: input.dry_run,
+        build_only: input.build_only,
+    };
+
+    let settled = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    let untap: (() => void) | null = null;
+
+    const finalize = () => {
+        if (timeoutHandle !== null) {
+            clearTimeout(timeoutHandle);
+            timeoutHandle = null;
+        }
+        if (untap) {
+            untap();
+            untap = null;
+        }
+        configurePipelineRunLock = false;
+    };
+
+    let abortFn: () => void = () => {};
+    configurePipelineRunLock = true;
+
+    const promise = new Promise<ConfigurePipelineResultNormalized>((resolve, reject) => {
+        const fail = (err: Error) => {
+            if (settled) return;
+            settled = true;
+            finalize();
+            reject(err);
+        };
+        const ok = (v: ConfigurePipelineResultNormalized) => {
+            if (settled) return;
+            settled = true;
+            finalize();
+            resolve(v);
+        };
+
+        const onJson = (msg: Record<string, unknown>) => {
+            if (msg.id !== goalId) return;
+            if (msg.op === 'action_feedback') {
+                callbacks?.onFeedback?.(normalizeConfigurePipelineFeedback(msg));
+            } else if (msg.op === 'action_result') {
+                if (msg.result === true) {
+                    ok(normalizeConfigurePipelineResult(msg));
+                } else {
+                    fail(new Error(normalizeConfigurePipelineResult(msg).message || 'ConfigurePipeline failed'));
+                }
+            }
+        };
+
+        untap = tapRosbridgeJson(ros, onJson);
+
+        timeoutHandle = setTimeout(() => {
+            fail(new Error(`ConfigurePipeline timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+
+        abortFn = () => {
+            if (settled) return;
+            try {
+                ros.callOnConnection({
+                    op: 'cancel_action_goal',
+                    id: goalId,
+                    action,
+                });
+            } catch {
+                /* ignore */
+            }
+            fail(new Error('ConfigurePipeline aborted.'));
+        };
+
+        try {
+            ros.callOnConnection({
+                op: 'send_action_goal',
+                id: goalId,
+                action,
+                action_type: actionType,
+                feedback: true,
+                args,
+            });
+        } catch (e) {
+            fail(e instanceof Error ? e : new Error('Failed to send action goal'));
+        }
+    });
+
+    return { promise, abort: () => abortFn() };
+}

--- a/src/Services/ros/handlers/HardwareConfig.handler.ts
+++ b/src/Services/ros/handlers/HardwareConfig.handler.ts
@@ -1,7 +1,7 @@
 /**
  * ROS transport only: hardware YAML validation and URDF cross-checks run on the
  * `lucy_config_services` node (`config/get`, `config/save`). The frontend displays
- * returned `message` / `validation_errors` / `urdf_warnings` without rewriting server text.
+ * returned `message` / `validation_errors` / `urdf_warnings` without rewriting backend text.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import ROSLIB from 'roslib';
@@ -55,8 +55,12 @@ function normalizeGetConfig(raw: any): GetConfigResponse {
     return {
         success,
         message: typeof raw?.message === 'string' ? raw.message : '',
+        robot_package: typeof raw?.robot_package === 'string' ? raw.robot_package : '',
         config_name: typeof raw?.config_name === 'string' ? raw.config_name : '',
         config_yaml: typeof raw?.config_yaml === 'string' ? raw.config_yaml : '',
+        flashed_config_name:
+            typeof raw?.flashed_config_name === 'string' ? raw.flashed_config_name : '',
+        flashed_at: typeof raw?.flashed_at === 'string' ? raw.flashed_at : '',
     };
 }
 
@@ -142,12 +146,12 @@ export class HardwareConfigHandler {
         return normalizeListConfigs(raw);
     }
 
-    static async activateConfig(configName: string): Promise<ActivateConfigResponse> {
+    static async activateConfig(configName: string, robotPackage: string): Promise<ActivateConfigResponse> {
         const raw = await callService(
             hardwareConfigServiceUri('activate'),
             HARDWARE_CONFIG_SERVICE_TYPES.activate,
             {
-                robot_package: '',
+                robot_package: robotPackage.trim(),
                 config_name: configName,
             },
         );

--- a/src/Services/ros/ros.service.ts
+++ b/src/Services/ros/ros.service.ts
@@ -28,19 +28,19 @@ class RosBridgeService {
         });
 
         ros.on('connection', () => {
-            logger('Connected to ROS websocket server.');
+            logger('Connected to ROS bridge.');
             this.clearConnectionTimeout();
             this.setConnectionStatus('connected');
         });
 
         ros.on('error', (error: any) => {
-            logger(`Error connecting to ROS websocket server: ${error}`);
+            logger(`Error connecting to ROS bridge: ${error}`);
             this.clearConnectionTimeout();
             this.setConnectionStatus('disconnected');
         });
 
         ros.on('close', () => {
-            logger('Connection to ROS websocket server closed.');
+            logger('ROS bridge connection closed.');
             this.clearConnectionTimeout();
             this.setConnectionStatus('disconnected');
         });

--- a/src/Utils/hardwareConfigServerErrors.ts
+++ b/src/Utils/hardwareConfigServerErrors.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react';
 import type { StructuredValidationLine } from '../Constants/hardwareConfigTypes.ts';
+import { uiErrorRgba } from '../Constants/uiTheme.ts';
 
 /** Lines that are not JSON structured errors from `format_error_lines`. */
 export const UNPARSED_VALIDATION_KEY = '_unparsed';
@@ -85,11 +86,11 @@ export function cellOutlineStyle(
 ): CSSProperties {
     const ef = opts.exactFieldKey;
     if (ef && (server.get(ef)?.length ?? 0) > 0) {
-        return { border: borders.exact, boxShadow: '0 0 6px rgba(255, 77, 79, 0.35)' };
+        return { border: borders.exact, boxShadow: `0 0 6px ${uiErrorRgba(0.35)}` };
     }
     const rp = opts.rowPrefix;
     if (rp && hasIssueUnderPrefix(server, rp)) {
-        return { border: borders.row, boxShadow: '0 0 4px rgba(255, 77, 79, 0.22)' };
+        return { border: borders.row, boxShadow: `0 0 4px ${uiErrorRgba(0.22)}` };
     }
     return { border: borders.ok };
 }

--- a/src/contexts/ActiveHardwareRosContext.tsx
+++ b/src/contexts/ActiveHardwareRosContext.tsx
@@ -21,9 +21,14 @@ export type ActiveHardwareFetchFail = { ok: false; message: string };
 export type ActiveHardwareFetchResult = ActiveHardwareFetchOk | ActiveHardwareFetchFail;
 
 interface ActiveHardwareRosContextValue {
-    /** Parsed active.yaml / pipeline active preset — server truth after successful fetch; cleared when disconnected. */
+    /** ROS package wired on lucy_config_pipeline (echo of GetConfig.robot_package); empty until fetched. */
+    serverRobotPackage: string;
+    /** Parsed active.yaml / pipeline active preset — system truth after successful fetch; cleared when disconnected. */
     activeHardwareDoc: Record<string, unknown> | null;
     activeHardwareConfigName: string;
+    /** Last preset recorded after pipeline flash (GetConfig.flashed_config_name); cleared when disconnected. */
+    serverFlashedConfigName: string;
+    serverFlashedAt: string;
     /** Derived joint/command routing when connected and fetch succeeded (possibly empty array). */
     controllerConfigsFromActive: ControllerJointConfig[] | null;
     activeHardwareLoading: boolean;
@@ -32,6 +37,10 @@ interface ActiveHardwareRosContextValue {
     activeHardwareFetchEpoch: number;
     /** Calls `/config/get` with empty name; updates shared snapshot used by control + configuration pages. */
     refetchActiveHardware: () => Promise<ActiveHardwareFetchResult>;
+    /** Non-empty robot_package strings from Config/get should be mirrored here (named loads too). */
+    recordServerRobotPackage: (robotPackage: string) => void;
+    /** `/config/get` also returns flashed preset meta — keep toolbar FLASHED in sync on named loads. */
+    recordServerFlashedMeta: (flashedConfigName: string, flashedAtIso: string) => void;
 }
 
 const ActiveHardwareRosContext = createContext<ActiveHardwareRosContextValue | null>(null);
@@ -40,12 +49,26 @@ export function ActiveHardwareRosProvider({ children }: { children: React.ReactN
     const { isConnected } = useRosConnection();
     const [activeHardwareDoc, setActiveHardwareDoc] = useState<Record<string, unknown> | null>(null);
     const [activeHardwareConfigName, setActiveHardwareConfigName] = useState('');
+    const [serverFlashedConfigName, setServerFlashedConfigName] = useState('');
+    const [serverFlashedAt, setServerFlashedAt] = useState('');
     const [controllerConfigsFromActive, setControllerConfigsFromActive] = useState<
         ControllerJointConfig[] | null
     >(null);
     const [activeHardwareLoading, setActiveHardwareLoading] = useState(false);
     const [activeHardwareError, setActiveHardwareError] = useState<string | null>(null);
     const [epoch, setEpoch] = useState(0);
+    const [serverRobotPackage, setServerRobotPackage] = useState('');
+
+    const recordServerRobotPackage = useCallback((robotPackage: string) => {
+        const t = robotPackage.trim();
+        if (!t) return;
+        setServerRobotPackage((prev) => (prev === t ? prev : t));
+    }, []);
+
+    const recordServerFlashedMeta = useCallback((flashedConfigName: string, flashedAtIso: string) => {
+        setServerFlashedConfigName(flashedConfigName.trim());
+        setServerFlashedAt(flashedAtIso.trim());
+    }, []);
 
     const refetchActiveHardware = useCallback(async (): Promise<ActiveHardwareFetchResult> => {
         if (!isConnected) {
@@ -60,12 +83,20 @@ export function ActiveHardwareRosProvider({ children }: { children: React.ReactN
                 setActiveHardwareError(msg);
                 setActiveHardwareDoc(null);
                 setControllerConfigsFromActive(null);
+                setServerFlashedConfigName('');
+                setServerFlashedAt('');
                 return { ok: false, message: msg };
+            }
+            const pkg = typeof res.robot_package === 'string' ? res.robot_package.trim() : '';
+            if (pkg) {
+                setServerRobotPackage(pkg);
             }
             const doc = parseHardwareConfigYaml(res.config_yaml || '');
             const ctrls = controllerJointConfigsFromHardwareYaml(doc);
             setActiveHardwareDoc(doc);
             setActiveHardwareConfigName(res.config_name || '');
+            setServerFlashedConfigName((res.flashed_config_name || '').trim());
+            setServerFlashedAt((res.flashed_at || '').trim());
             setControllerConfigsFromActive(ctrls);
             setEpoch((e) => e + 1);
             return { ok: true, doc, configName: res.config_name || '' };
@@ -74,6 +105,8 @@ export function ActiveHardwareRosProvider({ children }: { children: React.ReactN
             setActiveHardwareError(msg);
             setActiveHardwareDoc(null);
             setControllerConfigsFromActive(null);
+            setServerFlashedConfigName('');
+            setServerFlashedAt('');
             return { ok: false, message: msg };
         } finally {
             setActiveHardwareLoading(false);
@@ -84,9 +117,12 @@ export function ActiveHardwareRosProvider({ children }: { children: React.ReactN
         if (!isConnected) {
             setActiveHardwareDoc(null);
             setActiveHardwareConfigName('');
+            setServerFlashedConfigName('');
+            setServerFlashedAt('');
             setControllerConfigsFromActive(null);
             setActiveHardwareError(null);
             setActiveHardwareLoading(false);
+            setServerRobotPackage('');
             return;
         }
         void refetchActiveHardware();
@@ -94,22 +130,32 @@ export function ActiveHardwareRosProvider({ children }: { children: React.ReactN
 
     const value = useMemo(
         (): ActiveHardwareRosContextValue => ({
+            serverRobotPackage,
             activeHardwareDoc,
             activeHardwareConfigName,
+            serverFlashedConfigName,
+            serverFlashedAt,
             controllerConfigsFromActive,
             activeHardwareLoading,
             activeHardwareError,
             activeHardwareFetchEpoch: epoch,
             refetchActiveHardware,
+            recordServerRobotPackage,
+            recordServerFlashedMeta,
         }),
         [
+            serverRobotPackage,
             activeHardwareDoc,
             activeHardwareConfigName,
+            serverFlashedConfigName,
+            serverFlashedAt,
             controllerConfigsFromActive,
             activeHardwareLoading,
             activeHardwareError,
             epoch,
             refetchActiveHardware,
+            recordServerRobotPackage,
+            recordServerFlashedMeta,
         ],
     );
 

--- a/src/features/hardwareConfiguration/ConfigurationPage.tsx
+++ b/src/features/hardwareConfiguration/ConfigurationPage.tsx
@@ -1,52 +1,75 @@
-import {
-    Alert,
-    Button,
-    Card,
-    Modal,
-    Select,
-    Space,
-    Table,
-    Tag,
-    Typography,
-} from 'antd';
-import { DeleteOutlined, PlusOutlined, ReloadOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import { Alert, Button, Card, Select, Space, Table, Tag, Tooltip, Typography } from 'antd';
+import { PlusOutlined, ReloadOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { Page } from '../../Components/Page.tsx';
+import { HardwareConfigPresetHeaderTag } from '../../Components/HardwareConfigPresetTag.tsx';
 import { HardwareYamlConfigManager } from '../../Components/HardwareYamlConfigManager.tsx';
 import { LucyControlPanelHeader } from '../../Components/LucyControlPanelHeader.tsx';
 import { UNPARSED_VALIDATION_KEY, GENERAL_VALIDATION_KEY } from '../../Utils/hardwareConfigServerErrors.ts';
 import { UI_CARD_SURFACE_STYLE, UI_PRIMARY_GREEN_BUTTON_STYLE } from '../../Constants/uiTheme.ts';
 import './configuration.switch.css';
+import { ActivateConfigureWorkflowModal } from './components/ActivateConfigureWorkflowModal.tsx';
 import { useHardwareConfiguration } from './hooks/useHardwareConfiguration.tsx';
 import { freePhysicalPinsOnBoard } from './model/documentHelpers.ts';
 
 const { Text } = Typography;
 
 const ConfigurationPage = () => {
-    const [modal, contextHolder] = Modal.useModal();
-    const hw = useHardwareConfiguration(modal);
+    const hw = useHardwareConfiguration();
+    const editorLocked = hw.editorLocked;
 
     const headerContent = (
         <LucyControlPanelHeader>
-            <Space wrap>
-                <Tag title="Top-level robot_name from the loaded hardware YAML">
-                    <span style={{ fontWeight: 600 }}>ROBOT:</span> {hw.hardwareRobotName || '—'}
+            <div
+                style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'auto auto',
+                    columnGap: 12,
+                    rowGap: 6,
+                    alignItems: 'center',
+                }}
+            >
+                <span style={{ gridColumn: 1, gridRow: 1 }} aria-hidden />
+                <div style={{ gridColumn: 2, gridRow: 1 }}>
+                    <HardwareConfigPresetHeaderTag
+                        variant="loaded"
+                        label="LOADED"
+                        value={hw.resolvedName || ''}
+                        title="Configuration YAML currently open in the editor"
+                    />
+                </div>
+                <Tag
+                    title="ROS package wired on lucy_config_pipeline (from config/get)"
+                    style={{ gridColumn: 1, gridRow: 2, margin: 0 }}
+                >
+                    <span style={{ fontWeight: 600 }}>ROBOT PACKAGE:</span> {hw.serverRobotPackage || '—'}
                 </Tag>
-                <Tag color="cyan" title="Current active hardware configuration from config/list">
-                    <span style={{ fontWeight: 600 }}>ACTIVE:</span> {hw.serverActiveConfigName || '—'}
-                </Tag>
-                {hw.resolvedName ? (
-                    <Tag>
-                        <span style={{ fontWeight: 600 }}>LOADED:</span> {hw.resolvedName}
-                    </Tag>
-                ) : null}
-                {hw.isDirty ? <Tag color="orange">UNSAVED EDITS</Tag> : null}
-            </Space>
+                <div style={{ gridColumn: 2, gridRow: 2 }}>
+                    <HardwareConfigPresetHeaderTag
+                        variant="active"
+                        label="ACTIVE"
+                        value={hw.serverActiveConfigName || ''}
+                        title="Current active hardware configuration from config/list"
+                    />
+                </div>
+                <span style={{ gridColumn: 1, gridRow: 3 }} aria-hidden />
+                <div style={{ gridColumn: 2, gridRow: 3 }}>
+                    <HardwareConfigPresetHeaderTag
+                        variant="flashed"
+                        label="FLASHED"
+                        value={hw.serverFlashedConfigName || ''}
+                        title={
+                            hw.serverFlashedAt
+                                ? `Last successful pipeline flash (UTC): ${hw.serverFlashedAt}`
+                                : 'Preset last written to boards via configure_pipeline flash (from active_meta / config/get)'
+                        }
+                    />
+                </div>
+            </div>
         </LucyControlPanelHeader>
     );
 
     return (
         <Page showHeader headerContent={headerContent} contentStyle={{ padding: 12, position: 'relative' }} removeScrollbars={false}>
-            {contextHolder}
             {hw.contextHolderMessage}
 
             <div
@@ -61,6 +84,13 @@ const ConfigurationPage = () => {
                 }}
             >
                 <Space wrap align="center">
+                    <Button
+                        icon={<ReloadOutlined />}
+                        disabled={!hw.loadedSnapshot || editorLocked}
+                        onClick={hw.handleRevert}
+                    >
+                        REVERT
+                    </Button>
                     <HardwareYamlConfigManager
                         isConnected={hw.isConnected}
                         yamlDoc={hw.yamlDoc}
@@ -72,41 +102,36 @@ const ConfigurationPage = () => {
                         sensorPressureCount={hw.pressureSensorRows.length}
                         savedConfigNames={hw.savedConfigNames}
                         activeConfigName={hw.serverActiveConfigName}
+                        flashedConfigName={hw.serverFlashedConfigName}
                         configListLoading={hw.configListLoading}
                         toolbarTargetConfig={hw.loadConfigName}
                         onToolbarTargetConfigChange={hw.setLoadConfigName}
                         onRefreshConfigList={hw.refreshConfigListForModal}
                         onSaveConfig={hw.saveConfigByName}
                         onLoadConfig={(name) => hw.loadHardwareConfig(name, { successToast: false })}
+                        deleteConfigByName={hw.deleteConfigByName}
+                        deletingConfig={hw.deleting}
+                        workflowLocked={editorLocked}
                     />
-                    <Button icon={<ReloadOutlined />} disabled={!hw.loadedSnapshot} onClick={hw.handleRevert}>
-                        REVERT
-                    </Button>
+                    {hw.isDirty ? <Tag color="orange">UNSAVED EDITS</Tag> : null}
                 </Space>
                 <Space wrap align="center">
-                    <Button
-                        type="primary"
-                        icon={<ThunderboltOutlined />}
-                        loading={hw.activating}
-                        disabled={!hw.canActivateConfig}
-                        onClick={hw.handleActivateClick}
-                        style={UI_PRIMARY_GREEN_BUTTON_STYLE}
-                    >
-                        ACTIVATE
-                    </Button>
-                    <Button
-                        danger
-                        icon={<DeleteOutlined />}
-                        loading={hw.deleting}
-                        disabled={!hw.canDeleteConfig}
-                        onClick={hw.handleDeleteClick}
-                    >
-                        DELETE
-                    </Button>
-                    <Text type="secondary" style={{ fontFamily: 'monospace' }}>
-                        <span style={{ fontWeight: 600 }}>TARGET:</span>{' '}
-                        <Text code>{hw.selectedTargetConfigName || '—'}</Text>
-                    </Text>
+                    <HardwareConfigPresetHeaderTag
+                        variant="target"
+                        label="TARGET"
+                        value={hw.selectedTargetConfigName || ''}
+                    />
+                    <Tooltip title="Activate & configure the TARGET preset on the robot">
+                        <Button
+                            type="primary"
+                            icon={<ThunderboltOutlined />}
+                            loading={hw.workflowRunning}
+                            onClick={hw.openActivateModal}
+                            style={UI_PRIMARY_GREEN_BUTTON_STYLE}
+                        >
+                            ACTIVATE
+                        </Button>
+                    </Tooltip>
                 </Space>
             </div>
 
@@ -171,8 +196,37 @@ const ConfigurationPage = () => {
                 />
             ) : null}
 
+            <ActivateConfigureWorkflowModal
+                open={hw.activateModalOpen}
+                onClose={hw.closeActivateModal}
+                isDirty={hw.isDirty}
+                selectedTargetConfigName={hw.selectedTargetConfigName}
+                serverActiveConfigName={hw.serverActiveConfigName}
+                serverRobotPackage={hw.serverRobotPackage}
+                pipelineBoardOptions={hw.pipelineBoardOptions}
+                activateModalBoards={hw.activateModalBoards}
+                onActivateModalBoardsChange={hw.setActivateModalBoards}
+                activateModalBuildOnly={hw.activateModalBuildOnly}
+                onActivateModalBuildOnlyChange={hw.setActivateModalBuildOnly}
+                activateModalActivateOnly={hw.activateModalActivateOnly}
+                onActivateModalActivateOnlyChange={hw.setActivateModalActivateOnly}
+                onRun={hw.runWorkflowFromModal}
+                onAbort={hw.abortWorkflow}
+                workflowRunning={hw.workflowRunning}
+                workflowSteps={hw.workflowSteps}
+                workflowOverallPercent={hw.workflowOverallPercent}
+                workflowDetailLine={hw.workflowDetailLine}
+                canRun={hw.modalCanRun && hw.isConnected}
+            />
+
             {hw.yamlDoc ? (
-                <>
+                <div
+                    style={
+                        editorLocked
+                            ? { pointerEvents: 'none', opacity: 0.55, transition: 'opacity 0.2s ease' }
+                            : undefined
+                    }
+                >
                     <Card title="BOARDS (READ-ONLY)" size="small" style={{ marginBottom: 12, ...UI_CARD_SURFACE_STYLE }}>
                         <Table size="small" dataSource={hw.boardRows} columns={hw.boardColumns} pagination={false} />
                     </Card>
@@ -187,7 +241,11 @@ const ConfigurationPage = () => {
                                     size="small"
                                     placeholder="BOARD"
                                     style={{ minWidth: 200 }}
-                                    disabled={!hw.yamlDoc || hw.boardsEligibleForNewActuator.length === 0}
+                                    disabled={
+                                        editorLocked ||
+                                        !hw.yamlDoc ||
+                                        hw.boardsEligibleForNewActuator.length === 0
+                                    }
                                     value={hw.addActuatorBoard}
                                     options={hw.boardsEligibleForNewActuator.map((b) => ({
                                         value: b,
@@ -201,7 +259,7 @@ const ConfigurationPage = () => {
                                     type="default"
                                     size="small"
                                     className="hardware-config-add-btn"
-                                    disabled={!hw.yamlDoc || !hw.addActuatorBoard}
+                                    disabled={editorLocked || !hw.yamlDoc || !hw.addActuatorBoard}
                                     onClick={hw.handleAddActuator}
                                     style={{ minWidth: 132 }}
                                     title={
@@ -244,7 +302,11 @@ const ConfigurationPage = () => {
                                     style={{ minWidth: 260 }}
                                     showSearch
                                     optionFilterProp="label"
-                                    disabled={!hw.yamlDoc || hw.actuatorsEligibleForNewPressureSensor.length === 0}
+                                    disabled={
+                                        editorLocked ||
+                                        !hw.yamlDoc ||
+                                        hw.actuatorsEligibleForNewPressureSensor.length === 0
+                                    }
                                     value={hw.addPressureSensorActuatorId}
                                     allowClear
                                     options={hw.actuatorsEligibleForNewPressureSensor}
@@ -254,7 +316,7 @@ const ConfigurationPage = () => {
                                     type="default"
                                     size="small"
                                     className="hardware-config-add-btn"
-                                    disabled={!hw.yamlDoc || !hw.addPressureSensorActuatorId}
+                                    disabled={editorLocked || !hw.yamlDoc || !hw.addPressureSensorActuatorId}
                                     onClick={hw.handleAddPressureSensor}
                                     style={{ minWidth: 118 }}
                                     title={
@@ -284,7 +346,7 @@ const ConfigurationPage = () => {
                             columns={hw.pressureSensorColumns}
                         />
                     </Card>
-                </>
+                </div>
             ) : null}
         </Page>
     );

--- a/src/features/hardwareConfiguration/activateWorkflowStepTypes.ts
+++ b/src/features/hardwareConfiguration/activateWorkflowStepTypes.ts
@@ -1,0 +1,11 @@
+export type WorkflowStepId = 'validate' | 'activate' | 'build' | 'flash';
+
+export type WorkflowStepRuntimeStatus = 'pending' | 'running' | 'done' | 'error' | 'skipped';
+
+export interface WorkflowStepSlice {
+    id: WorkflowStepId;
+    title: string;
+    status: WorkflowStepRuntimeStatus;
+    fraction: number;
+    detail: string;
+}

--- a/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
+++ b/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
@@ -1,0 +1,272 @@
+import {
+    CheckCircleOutlined,
+    CloseCircleOutlined,
+    LoadingOutlined,
+    MinusCircleOutlined,
+    ThunderboltOutlined,
+} from '@ant-design/icons';
+import { Button, Card, Checkbox, Divider, Modal, Progress, Space, Switch, Typography } from 'antd';
+import { HardwareConfigPresetHeaderTag } from '../../../Components/HardwareConfigPresetTag.tsx';
+import {
+    UI_ACCENT_GREEN,
+    UI_BORDER_MUTED,
+    UI_BORDER_SOFT,
+    UI_CARD_SURFACE_STYLE,
+    UI_ERROR_RED,
+    UI_MODAL_MASK_BG,
+    UI_PRIMARY_GREEN_BUTTON_STYLE,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SECONDARY_MUTED,
+    UI_TEXT_SUBTLE,
+    UI_WARNING_AMBER,
+} from '../../../Constants/uiTheme.ts';
+import type { WorkflowStepRuntimeStatus, WorkflowStepSlice } from '../activateWorkflowStepTypes.ts';
+import '../configuration.switch.css';
+
+const { Text, Title } = Typography;
+
+const modalStyles = {
+    mask: { backgroundColor: UI_MODAL_MASK_BG },
+};
+
+function stepIcon(status: WorkflowStepRuntimeStatus) {
+    if (status === 'done') return <CheckCircleOutlined style={{ color: UI_ACCENT_GREEN }} />;
+    if (status === 'error') return <CloseCircleOutlined style={{ color: UI_ERROR_RED }} />;
+    if (status === 'skipped') return <MinusCircleOutlined style={{ color: UI_TEXT_SECONDARY_MUTED }} />;
+    if (status === 'running') return <LoadingOutlined style={{ color: UI_ACCENT_GREEN }} />;
+    return (
+        <span
+            style={{
+                display: 'inline-block',
+                width: 14,
+                height: 14,
+                borderRadius: '50%',
+                border: `2px solid ${UI_BORDER_SOFT}`,
+            }}
+        />
+    );
+}
+
+export interface ActivateConfigureWorkflowModalProps {
+    open: boolean;
+    onClose: () => void;
+    isDirty: boolean;
+    selectedTargetConfigName: string;
+    serverActiveConfigName: string;
+    serverRobotPackage: string;
+    pipelineBoardOptions: { label: string; value: string }[];
+    activateModalBoards: string[];
+    onActivateModalBoardsChange: (ids: string[]) => void;
+    activateModalBuildOnly: boolean;
+    onActivateModalBuildOnlyChange: (v: boolean) => void;
+    activateModalActivateOnly: boolean;
+    onActivateModalActivateOnlyChange: (v: boolean) => void;
+    /** Primary action */
+    onRun: () => void | Promise<void>;
+    onAbort: () => void;
+    workflowRunning: boolean;
+    workflowSteps: WorkflowStepSlice[];
+    workflowOverallPercent: number;
+    workflowDetailLine: string;
+    canRun: boolean;
+}
+
+export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowModalProps) {
+    const {
+        open,
+        onClose,
+        isDirty,
+        selectedTargetConfigName,
+        serverActiveConfigName,
+        serverRobotPackage,
+        pipelineBoardOptions,
+        activateModalBoards,
+        onActivateModalBoardsChange,
+        activateModalBuildOnly,
+        onActivateModalBuildOnlyChange,
+        activateModalActivateOnly,
+        onActivateModalActivateOnlyChange,
+        onRun,
+        onAbort,
+        workflowRunning,
+        workflowSteps,
+        workflowOverallPercent,
+        workflowDetailLine,
+        canRun,
+    } = props;
+
+    return (
+        <Modal
+            title={
+                <Title level={4} style={{ color: UI_ACCENT_GREEN, margin: 0 }}>
+                    <ThunderboltOutlined /> ACTIVATE &amp; CONFIGURE
+                </Title>
+            }
+            open={open}
+            onCancel={workflowRunning ? () => {} : onClose}
+            footer={null}
+            keyboard={!workflowRunning}
+            width={720}
+            style={{ top: 48 }}
+            styles={modalStyles}
+            className="dark-modal"
+            maskClosable={!workflowRunning}
+            closable={!workflowRunning}
+            destroyOnClose={false}
+        >
+            <Space direction="vertical" style={{ width: '100%' }} size="middle">
+                {serverActiveConfigName && serverActiveConfigName !== selectedTargetConfigName ? (
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                        Current active on system: <Text code>{serverActiveConfigName}</Text>
+                    </Text>
+                ) : null}
+                {isDirty ? (
+                    <Text type="warning" style={{ fontSize: 12 }}>
+                        Unsaved editor changes — this workflow uses files already saved on the system. Save first if
+                        needed.
+                    </Text>
+                ) : null}
+
+                <div>
+                    <Text style={{ color: UI_TEXT_SUBTLE, fontSize: 12, marginBottom: 8, display: 'block' }}>
+                        BOARDS
+                        {pipelineBoardOptions.length > 0 ? (
+                            <Text type="secondary" style={{ fontSize: 12 }}>
+                                {' '}
+                                — none selected → ACTIVATE ONLY (no build / flash)
+                            </Text>
+                        ) : null}
+                    </Text>
+                    {pipelineBoardOptions.length === 0 ? (
+                        <Text type="secondary">No boards in the loaded YAML — system mapping applies.</Text>
+                    ) : (
+                        <Checkbox.Group
+                            className="hardware-config-ant-checkbox-group"
+                            options={pipelineBoardOptions}
+                            value={activateModalBoards}
+                            onChange={(vals) => onActivateModalBoardsChange(vals.map(String))}
+                            disabled={workflowRunning}
+                        />
+                    )}
+                </div>
+                <div>
+                    <Switch
+                        className="hardware-config-ant-switch"
+                        checked={activateModalActivateOnly}
+                        onChange={onActivateModalActivateOnlyChange}
+                        disabled={workflowRunning}
+                    />
+                    <Text style={{ marginLeft: 8 }}>ACTIVATE ONLY (NO BUILD / FLASH)</Text>
+                </div>
+                <div>
+                    <Switch
+                        className="hardware-config-ant-switch"
+                        checked={activateModalBuildOnly}
+                        onChange={onActivateModalBuildOnlyChange}
+                        disabled={workflowRunning}
+                    />
+                    <Text style={{ marginLeft: 8 }}>BUILD ONLY (NO FLASH)</Text>
+                </div>
+
+                <Card size="small" style={{ ...UI_CARD_SURFACE_STYLE }}>
+                    <HardwareConfigPresetHeaderTag
+                        variant="target"
+                        label="TARGET"
+                        value={selectedTargetConfigName || ''}
+                    />
+                    <Divider type="vertical" />
+                    <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK }}>
+                        ROBOT PACKAGE:{' '}
+                    </Text>
+                    <Text style={{ color: UI_ACCENT_GREEN }}>{serverRobotPackage || '—'}</Text>
+                </Card>
+
+                <Divider style={{ margin: '8px 0' }} />
+
+                <div>
+                    <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK, display: 'block', marginBottom: 8 }}>
+                        PROGRESS
+                    </Text>
+                    <Progress
+                        percent={workflowOverallPercent}
+                        status={workflowRunning ? 'active' : undefined}
+                        strokeColor={UI_ACCENT_GREEN}
+                    />
+                    <div
+                        style={{
+                            display: 'grid',
+                            gridTemplateColumns: 'repeat(4, 1fr)',
+                            gap: 8,
+                            marginTop: 12,
+                        }}
+                    >
+                        {workflowSteps.map((s) => (
+                            <Card
+                                key={s.id}
+                                size="small"
+                                style={{
+                                    ...UI_CARD_SURFACE_STYLE,
+                                    borderColor: s.status === 'running' ? UI_ACCENT_GREEN : UI_BORDER_MUTED,
+                                    opacity: s.status === 'pending' ? 0.75 : 1,
+                                }}
+                            >
+                                <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                                    <Space size={6}>
+                                        {stepIcon(s.status)}
+                                        <Text strong style={{ color: UI_TEXT_PRIMARY_ON_DARK, fontSize: 12 }}>
+                                            {s.title}
+                                        </Text>
+                                    </Space>
+                                    {s.status === 'running' ? (
+                                        <Progress
+                                            percent={Math.round(s.fraction * 100)}
+                                            size="small"
+                                            showInfo={false}
+                                            strokeColor={UI_WARNING_AMBER}
+                                        />
+                                    ) : null}
+                                    {s.detail ? (
+                                        <Text type="secondary" style={{ fontSize: 10, lineHeight: 1.3 }}>
+                                            {s.detail}
+                                        </Text>
+                                    ) : null}
+                                </Space>
+                            </Card>
+                        ))}
+                    </div>
+                    {workflowDetailLine ? (
+                        <Text type="secondary" style={{ display: 'block', marginTop: 10, fontSize: 12 }}>
+                            {workflowDetailLine}
+                        </Text>
+                    ) : null}
+                </div>
+
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 8 }}>
+                    {workflowRunning ? (
+                        <Button danger onClick={onAbort}>
+                            ABORT
+                        </Button>
+                    ) : (
+                        <span />
+                    )}
+                    <Space>
+                        <Button onClick={onClose} disabled={workflowRunning}>
+                            CANCEL
+                        </Button>
+                        {!workflowRunning ? (
+                            <Button
+                                type="primary"
+                                icon={<ThunderboltOutlined />}
+                                onClick={() => void onRun()}
+                                disabled={!canRun}
+                                style={UI_PRIMARY_GREEN_BUTTON_STYLE}
+                            >
+                                RUN
+                            </Button>
+                        ) : null}
+                    </Space>
+                </div>
+            </Space>
+        </Modal>
+    );
+}

--- a/src/features/hardwareConfiguration/configuration.switch.css
+++ b/src/features/hardwareConfiguration/configuration.switch.css
@@ -1,21 +1,21 @@
-/* Add actuator / sensor (Card extra): always black label + icon; disabled avoids faded white text. */
+/* Palette via document vars — set in TS (mountUiThemeCssVars). */
 .hardware-config-add-btn.ant-btn {
-    color: #000 !important;
+    color: var(--ui-text-on-accent) !important;
     font-weight: 600;
 }
 .hardware-config-add-btn.ant-btn .anticon {
-    color: #000 !important;
+    color: var(--ui-text-on-accent) !important;
 }
 .hardware-config-add-btn.ant-btn:not(:disabled):not(.ant-btn-disabled) {
-    background-color: #00ff41 !important;
-    border-color: #00ff41 !important;
-    color: #000 !important;
+    background-color: var(--ui-accent-green) !important;
+    border-color: var(--ui-accent-green) !important;
+    color: var(--ui-text-on-accent) !important;
 }
 .hardware-config-add-btn.ant-btn:disabled,
 .hardware-config-add-btn.ant-btn.ant-btn-disabled {
-    background-color: #555 !important;
-    border-color: #666 !important;
-    color: #000 !important;
+    background-color: var(--ui-switch-disabled-bg) !important;
+    border-color: var(--ui-switch-disabled-border) !important;
+    color: var(--ui-text-on-accent) !important;
     opacity: 1 !important;
 }
 
@@ -29,5 +29,10 @@
 }
 
 .ant-switch.hardware-config-ant-switch .ant-switch-handle::before {
+    border-radius: 0 !important;
+}
+
+/* Activate modal board picker — square checkbox boxes */
+.hardware-config-ant-checkbox-group.ant-checkbox-group .ant-checkbox .ant-checkbox-inner {
     border-radius: 0 !important;
 }

--- a/src/features/hardwareConfiguration/hooks/hardwareConfigEditorParams.ts
+++ b/src/features/hardwareConfiguration/hooks/hardwareConfigEditorParams.ts
@@ -1,10 +1,11 @@
-import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
 import type { MessageInstance } from 'antd/es/message/interface';
 import type { ActiveHardwareFetchResult } from '../../../contexts/ActiveHardwareRosContext.tsx';
 
 export interface HardwareConfigEditorParams {
-    modal: Pick<ModalStaticFunctions, 'confirm'>;
     messageApi: MessageInstance;
+    /** Mirror `GetConfig.robot_package` into shared context when loading a named preset. */
+    recordServerRobotPackage: (robotPackage: string) => void;
+    recordServerFlashedMeta: (flashedConfigName: string, flashedAtIso: string) => void;
     refreshSavedConfigs: () => Promise<string | undefined>;
     serverActiveConfigName: string;
     activeHardwareDoc: Record<string, unknown> | null;

--- a/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
+++ b/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
@@ -1,0 +1,298 @@
+import type { MessageInstance } from 'antd/es/message/interface';
+import { useCallback, useRef, useState } from 'react';
+import type { ConfigurePipelineFeedbackNormalized } from '../../../Constants/hardwareConfigTypes.ts';
+import { HardwareConfigHandler } from '../../../Services/ros/handlers/HardwareConfig.handler.ts';
+import { startConfigurePipeline } from '../../../Services/ros/handlers/ConfigurePipeline.handler.ts';
+import type {
+    WorkflowStepId,
+    WorkflowStepSlice,
+} from '../activateWorkflowStepTypes.ts';
+
+function initialSteps(buildOnly: boolean, activateOnly: boolean): WorkflowStepSlice[] {
+    return [
+        { id: 'validate', title: 'VALIDATE', status: 'pending', fraction: 0, detail: '' },
+        { id: 'activate', title: 'ACTIVATE', status: 'pending', fraction: 0, detail: '' },
+        {
+            id: 'build',
+            title: 'BUILD',
+            status: activateOnly ? 'skipped' : 'pending',
+            fraction: 0,
+            detail: activateOnly ? 'Skipped (activate only)' : '',
+        },
+        {
+            id: 'flash',
+            title: 'FLASH',
+            status: buildOnly || activateOnly ? 'skipped' : 'pending',
+            fraction: 0,
+            detail: buildOnly ? 'Skipped (build only)' : activateOnly ? 'Skipped (activate only)' : '',
+        },
+    ];
+}
+
+export function computeWorkflowOverallPercent(steps: WorkflowStepSlice[]): number {
+    const applicable = steps.filter((s) => s.status !== 'skipped');
+    if (applicable.length === 0) return 0;
+    const w = 1 / applicable.length;
+    let sum = 0;
+    for (const s of applicable) {
+        if (s.status === 'done') sum += w;
+        else if (s.status === 'running') {
+            sum += w * Math.max(0, Math.min(1, s.fraction));
+            break;
+        } else break;
+    }
+    return Math.round(sum * 100);
+}
+
+function fractionForBuildAggregate(f: ConfigurePipelineFeedbackNormalized): number {
+    const p = f.phase?.toLowerCase() ?? '';
+    if (p === 'validate') return Math.max(0, Math.min(1, f.progress * 0.2));
+    if (p === 'generate') return Math.max(0, Math.min(1, 0.2 + f.progress * 0.35));
+    if (p === 'build') return Math.max(0, Math.min(1, 0.55 + f.progress * 0.45));
+    return Math.max(0, Math.min(1, f.progress));
+}
+
+function fractionForValidateDryRun(f: ConfigurePipelineFeedbackNormalized): number {
+    const p = f.phase?.toLowerCase() ?? '';
+    if (p === 'validate') return Math.max(0, Math.min(1, f.progress * 0.55));
+    if (p === 'generate') return Math.max(0, Math.min(1, 0.45 + f.progress * 0.55));
+    return Math.max(0, Math.min(1, f.progress));
+}
+
+export interface UseActivateConfigureWorkflowParams {
+    messageApi: MessageInstance;
+    isConnected: boolean;
+    robotPackageName: string;
+    refetchActiveHardware: () => Promise<unknown>;
+}
+
+export function useActivateConfigureWorkflow({
+    messageApi,
+    isConnected,
+    robotPackageName,
+    refetchActiveHardware,
+}: UseActivateConfigureWorkflowParams) {
+    const [workflowRunning, setWorkflowRunning] = useState(false);
+    const [steps, setSteps] = useState<WorkflowStepSlice[]>(() => initialSteps(false, false));
+    const [detailLine, setDetailLine] = useState('');
+    const abortRef = useRef<(() => void) | null>(null);
+    const runIdRef = useRef(0);
+
+    const workflowOverallPercent = computeWorkflowOverallPercent(steps);
+
+    const abortWorkflow = useCallback(() => {
+        abortRef.current?.();
+        abortRef.current = null;
+    }, []);
+
+    const resetWorkflowPresentation = useCallback((buildOnly: boolean, activateOnly: boolean) => {
+        setSteps(initialSteps(buildOnly, activateOnly));
+        setDetailLine('');
+    }, []);
+
+    const patchStep = useCallback((id: WorkflowStepId, patch: Partial<Omit<WorkflowStepSlice, 'id' | 'title'>>) => {
+        setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+    }, []);
+
+    const runActivateWorkflow = useCallback(
+        async (params: {
+            targetConfigName: string;
+            boardsToFlash: string[];
+            buildOnly: boolean;
+            activateOnly: boolean;
+            refreshSavedConfigs: () => Promise<unknown>;
+        }) => {
+            const { targetConfigName, boardsToFlash, buildOnly, activateOnly } = params;
+            const rp = robotPackageName.trim();
+            if (!isConnected) {
+                messageApi.error('Connect to ROS bridge first.');
+                return;
+            }
+            if (!targetConfigName.trim()) {
+                messageApi.warning('Pick a TARGET configuration.');
+                return;
+            }
+            if (!rp) {
+                messageApi.error('Robot package is not known yet — wait for config/get.');
+                return;
+            }
+
+            const runId = ++runIdRef.current;
+            abortRef.current = null;
+            setWorkflowRunning(true);
+            setSteps(initialSteps(buildOnly, activateOnly));
+            setDetailLine('');
+
+            const shouldContinue = () => runId === runIdRef.current;
+
+            const failStep = (id: WorkflowStepId, msg: string) => {
+                if (!shouldContinue()) return;
+                patchStep(id, { status: 'error', fraction: 1, detail: msg });
+                setDetailLine(msg);
+                messageApi.error(msg);
+            };
+
+            try {
+                patchStep('validate', { status: 'running', fraction: 0, detail: 'Dry run…' });
+                setDetailLine('VALIDATE — dry run against TARGET mapping…');
+
+                const dry = startConfigurePipeline(
+                    {
+                        robot_package: rp,
+                        mapping_file: targetConfigName.trim(),
+                        boards_to_flash: boardsToFlash,
+                        dry_run: true,
+                        build_only: false,
+                    },
+                    {
+                        onFeedback: (f) => {
+                            if (!shouldContinue()) return;
+                            setDetailLine(f.detail || `VALIDATE — ${f.phase}`);
+                            patchStep('validate', {
+                                status: 'running',
+                                fraction: fractionForValidateDryRun(f),
+                                detail: f.detail || f.phase,
+                            });
+                        },
+                    },
+                );
+                abortRef.current = dry.abort;
+
+                const dryRes = await dry.promise;
+                abortRef.current = null;
+                if (!shouldContinue()) return;
+
+                if (!dryRes.success) {
+                    failStep('validate', dryRes.message || 'Validation failed');
+                    return;
+                }
+                patchStep('validate', { status: 'done', fraction: 1, detail: 'OK' });
+
+                patchStep('activate', { status: 'running', fraction: 0.5, detail: '/config/activate…' });
+                setDetailLine('ACTIVATE — promoting preset to active…');
+
+                const act = await HardwareConfigHandler.activateConfig(targetConfigName.trim(), rp);
+                if (!shouldContinue()) return;
+                if (!act.success) {
+                    failStep('activate', act.message || 'Activate failed');
+                    return;
+                }
+                const backup = act.backup_name?.trim();
+                patchStep('activate', {
+                    status: 'done',
+                    fraction: 1,
+                    detail: backup ? `Backup: ${backup}` : 'OK',
+                });
+                await params.refreshSavedConfigs();
+                await refetchActiveHardware();
+
+                if (activateOnly) {
+                    patchStep('build', {
+                        status: 'skipped',
+                        fraction: 0,
+                        detail: 'Skipped (activate only)',
+                    });
+                    patchStep('flash', {
+                        status: 'skipped',
+                        fraction: 0,
+                        detail: 'Skipped (activate only)',
+                    });
+                    setDetailLine('Activated — build and flash skipped.');
+                    await refetchActiveHardware();
+                    messageApi.success('Configuration activated (build and flash skipped).');
+                    return;
+                }
+
+                patchStep('build', { status: 'running', fraction: 0, detail: '' });
+                if (!buildOnly) {
+                    patchStep('flash', { status: 'pending', fraction: 0, detail: '' });
+                }
+                setDetailLine('BUILD — pipeline on active mapping…');
+
+                let sawFlash = false;
+                const wet = startConfigurePipeline(
+                    {
+                        robot_package: rp,
+                        mapping_file: '',
+                        boards_to_flash: boardsToFlash,
+                        dry_run: false,
+                        build_only: buildOnly,
+                    },
+                    {
+                        onFeedback: (f: ConfigurePipelineFeedbackNormalized) => {
+                            if (!shouldContinue()) return;
+                            const phase = (f.phase || '').toLowerCase();
+                            setDetailLine(f.detail || `${phase.toUpperCase()}…`);
+
+                            if (phase === 'flash') {
+                                sawFlash = true;
+                                patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
+                                patchStep('flash', {
+                                    status: 'running',
+                                    fraction: Math.max(0, Math.min(1, f.progress)),
+                                    detail: f.detail || phase,
+                                });
+                            } else {
+                                patchStep('build', {
+                                    status: 'running',
+                                    fraction: fractionForBuildAggregate(f),
+                                    detail: f.detail || phase,
+                                });
+                            }
+                        },
+                    },
+                );
+                abortRef.current = wet.abort;
+
+                const wetRes = await wet.promise;
+                abortRef.current = null;
+                if (!shouldContinue()) return;
+
+                if (!wetRes.success) {
+                    const msg = wetRes.message || 'Configure pipeline failed';
+                    if (buildOnly || !sawFlash) failStep('build', msg);
+                    else failStep('flash', msg);
+                    return;
+                }
+
+                patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
+                if (buildOnly) {
+                    patchStep('flash', {
+                        status: 'skipped',
+                        fraction: 0,
+                        detail: 'Skipped (build only)',
+                    });
+                } else {
+                    patchStep('flash', { status: 'done', fraction: 1, detail: 'OK' });
+                }
+                setDetailLine(wetRes.message || 'Complete');
+                await refetchActiveHardware();
+                messageApi.success(`Workflow finished: ${wetRes.message || 'OK'}`);
+            } catch (e) {
+                if (!shouldContinue()) return;
+                const msg = e instanceof Error ? e.message : 'Workflow failed';
+                setDetailLine(msg);
+                messageApi.error(msg);
+                setSteps((prev) =>
+                    prev.map((s) =>
+                        s.status === 'running' ? { ...s, status: 'error', detail: msg, fraction: s.fraction } : s,
+                    ),
+                );
+            } finally {
+                abortRef.current = null;
+                if (runId === runIdRef.current) setWorkflowRunning(false);
+            }
+        },
+        [isConnected, messageApi, patchStep, refetchActiveHardware, robotPackageName],
+    );
+
+    return {
+        workflowRunning,
+        workflowSteps: steps,
+        workflowOverallPercent,
+        workflowDetailLine: detailLine,
+        runActivateWorkflow,
+        abortWorkflow,
+        resetWorkflowPresentation,
+    };
+}

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigEditor.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigEditor.tsx
@@ -9,7 +9,7 @@ import { useHardwareYamlEditorState } from './useHardwareYamlEditorState.ts';
 export type { HardwareConfigEditorParams } from './hardwareConfigEditorParams.ts';
 
 /**
- * Composes YAML snapshot state, derived tables, local mutations, ROS server ops, and Ant Design columns for the hardware configuration page.
+ * Composes YAML snapshot state, derived tables, local mutations, ROS hardware-config ops, and Ant Design columns for the hardware configuration page.
  */
 export function useHardwareConfigEditor(params: HardwareConfigEditorParams) {
     const { isConnected } = useRosConnection();
@@ -32,11 +32,8 @@ export function useHardwareConfigEditor(params: HardwareConfigEditorParams) {
     });
 
     const server = useHardwareConfigServerOps({
-        modal: params.modal,
         messageApi: params.messageApi,
         isConnected,
-        isDirty: yaml.isDirty,
-        serverActiveConfigName: params.serverActiveConfigName,
         loadConfigName: yaml.loadConfigName,
         setLoadConfigName: yaml.setLoadConfigName,
         yamlDoc: yaml.yamlDoc,
@@ -54,6 +51,8 @@ export function useHardwareConfigEditor(params: HardwareConfigEditorParams) {
         clearServerValidation: yaml.clearServerValidation,
         refreshSavedConfigs: params.refreshSavedConfigs,
         refetchActiveHardware: params.refetchActiveHardware,
+        recordServerRobotPackage: params.recordServerRobotPackage,
+        recordServerFlashedMeta: params.recordServerFlashedMeta,
     });
 
     const { serverErrorRows, boardColumns, actuatorColumns, pressureSensorColumns } = useHardwareConfigEditorColumns({

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigServerOps.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigServerOps.tsx
@@ -1,19 +1,13 @@
-import { ExclamationCircleOutlined } from '@ant-design/icons';
-import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
 import type { MessageInstance } from 'antd/es/message/interface';
 import { useCallback, useState } from 'react';
-import { UI_ERROR_RED, UI_WARNING_AMBER } from '../../../Constants/uiTheme.ts';
 import type { ActiveHardwareFetchResult } from '../../../contexts/ActiveHardwareRosContext.tsx';
 import { HardwareConfigHandler } from '../../../Services/ros/handlers/HardwareConfig.handler.ts';
 import { mapStructuredValidationErrors } from '../../../Utils/hardwareConfigServerErrors.ts';
 import { parseHardwareConfigYaml, stringifyHardwareConfigYaml } from '../../../Utils/hardwareConfigYaml.ts';
 
 export interface HardwareConfigServerOpsParams {
-    modal: Pick<ModalStaticFunctions, 'confirm'>;
     messageApi: MessageInstance;
     isConnected: boolean;
-    isDirty: boolean;
-    serverActiveConfigName: string;
     loadConfigName: string;
     setLoadConfigName: (v: string | ((p: string) => string)) => void;
     yamlDoc: Record<string, unknown> | null;
@@ -31,17 +25,16 @@ export interface HardwareConfigServerOpsParams {
     clearServerValidation: () => void;
     refreshSavedConfigs: () => Promise<string | undefined>;
     refetchActiveHardware: () => Promise<ActiveHardwareFetchResult>;
+    recordServerRobotPackage: (robotPackage: string) => void;
+    recordServerFlashedMeta: (flashedConfigName: string, flashedAtIso: string) => void;
 }
 
 /**
  * Load / save / revert / activate / delete flows against the ROS hardware-config service.
  */
 export function useHardwareConfigServerOps({
-    modal,
     messageApi,
     isConnected,
-    isDirty,
-    serverActiveConfigName,
     loadConfigName,
     setLoadConfigName,
     yamlDoc,
@@ -59,8 +52,9 @@ export function useHardwareConfigServerOps({
     clearServerValidation,
     refreshSavedConfigs,
     refetchActiveHardware,
+    recordServerRobotPackage,
+    recordServerFlashedMeta,
 }: HardwareConfigServerOpsParams) {
-    const [activating, setActivating] = useState(false);
     const [deleting, setDeleting] = useState(false);
 
     const loadHardwareConfig = useCallback(
@@ -96,6 +90,8 @@ export function useHardwareConfigServerOps({
                     messageApi.error(res.message || 'Load failed');
                     return false;
                 }
+                recordServerRobotPackage(res.robot_package ?? '');
+                recordServerFlashedMeta(res.flashed_config_name ?? '', res.flashed_at ?? '');
                 const doc = parseHardwareConfigYaml(res.config_yaml || '');
                 setYamlDoc(doc);
                 setLoadedSnapshot(structuredClone(doc));
@@ -125,94 +121,38 @@ export function useHardwareConfigServerOps({
             setLoadConfigName,
             setIsDirty,
             setLoading,
+            recordServerRobotPackage,
+            recordServerFlashedMeta,
         ],
     );
 
-    const runActivateConfig = useCallback(async () => {
-        const name = loadConfigName.trim();
-        if (!name) return;
-        setActivating(true);
-        try {
-            const r = await HardwareConfigHandler.activateConfig(name);
-            if (!r.success) {
-                messageApi.error(r.message || 'Activate failed');
-                return;
+    const deleteConfigByName = useCallback(
+        async (configName: string): Promise<boolean> => {
+            const name = configName.trim();
+            if (!name) return false;
+            setDeleting(true);
+            try {
+                const r = await HardwareConfigHandler.deleteConfig(name);
+                if (!r.success) {
+                    messageApi.error(r.message || 'Delete failed');
+                    return false;
+                }
+                messageApi.success(`Deleted configuration "${name}".`);
+                const targetWasDeleted = loadConfigName.trim() === name;
+                const activeAfterList = await refreshSavedConfigs();
+                if (targetWasDeleted) {
+                    setLoadConfigName(activeAfterList ?? '');
+                }
+                return true;
+            } catch (e) {
+                messageApi.error(e instanceof Error ? e.message : 'Delete failed');
+                return false;
+            } finally {
+                setDeleting(false);
             }
-            const backup = r.backup_name?.trim();
-            messageApi.success(
-                backup
-                    ? `Activated "${name}". Previous active backed up as "${backup}".`
-                    : `Activated "${name}".`,
-            );
-            await refreshSavedConfigs();
-            await refetchActiveHardware();
-        } catch (e) {
-            messageApi.error(e instanceof Error ? e.message : 'Activate failed');
-        } finally {
-            setActivating(false);
-        }
-    }, [loadConfigName, messageApi, refreshSavedConfigs, refetchActiveHardware]);
-
-    const handleActivateClick = useCallback(() => {
-        const name = loadConfigName.trim();
-        if (!name) return;
-        const bits = [
-            `Copies the saved configuration "${name}" to active.yaml on the robot.`,
-            serverActiveConfigName && serverActiveConfigName !== name
-                ? `Currently active configuration: ${serverActiveConfigName}.`
-                : null,
-            isDirty
-                ? 'You have unsaved editor changes — SAVE writes them to this configuration file first. Activate uses whatever is already saved on the server.'
-                : null,
-        ].filter(Boolean);
-        modal.confirm({
-            title: `ACTIVATE CONFIGURATION "${name}"?`,
-            icon: <ExclamationCircleOutlined style={{ color: UI_WARNING_AMBER }} />,
-            content: <span>{bits.join(' ')}</span>,
-            okText: 'ACTIVATE',
-            cancelText: 'CANCEL',
-            okType: 'danger',
-            onOk: runActivateConfig,
-        });
-    }, [loadConfigName, serverActiveConfigName, isDirty, modal, runActivateConfig]);
-
-    const runDeleteConfig = useCallback(async () => {
-        const name = loadConfigName.trim();
-        if (!name) return;
-        setDeleting(true);
-        try {
-            const r = await HardwareConfigHandler.deleteConfig(name);
-            if (!r.success) {
-                messageApi.error(r.message || 'Delete failed');
-                return;
-            }
-            messageApi.success(`Deleted configuration "${name}".`);
-            const targetWasDeleted = loadConfigName.trim() === name;
-            const activeAfterList = await refreshSavedConfigs();
-            if (targetWasDeleted) {
-                setLoadConfigName(activeAfterList ?? '');
-            }
-        } catch (e) {
-            messageApi.error(e instanceof Error ? e.message : 'Delete failed');
-        } finally {
-            setDeleting(false);
-        }
-    }, [loadConfigName, messageApi, refreshSavedConfigs, setLoadConfigName]);
-
-    const handleDeleteClick = useCallback(() => {
-        const name = loadConfigName.trim();
-        if (!name) return;
-        modal.confirm({
-            title: `DELETE "${name}"?`,
-            icon: <ExclamationCircleOutlined style={{ color: UI_ERROR_RED }} />,
-            content:
-                'THIS REMOVES THE TARGETED CONFIG (IF IT IS NOT THE ACTIVE CONFIGURATION OR "DEFAULT")',
-            okText: 'DELETE',
-            cancelText: 'CANCEL',
-            okButtonProps: { danger: true },
-            onOk: runDeleteConfig,
-        });
-    }, [loadConfigName, modal, runDeleteConfig]);
+        },
+        [loadConfigName, messageApi, refreshSavedConfigs, setLoadConfigName],
+    );
 
     const handleRevert = useCallback(() => {
         if (!loadedSnapshot) {
@@ -293,29 +233,14 @@ export function useHardwareConfigServerOps({
     }, [refreshSavedConfigs]);
 
     const selectedTargetConfigName = loadConfigName.trim();
-    const canActivateConfig =
-        isConnected &&
-        Boolean(selectedTargetConfigName) &&
-        selectedTargetConfigName !== serverActiveConfigName &&
-        !activating;
-    const canDeleteConfig =
-        isConnected &&
-        Boolean(selectedTargetConfigName) &&
-        selectedTargetConfigName !== 'default' &&
-        selectedTargetConfigName !== serverActiveConfigName &&
-        !deleting;
 
     return {
         loadHardwareConfig,
         handleRevert,
         saveConfigByName,
         refreshConfigListForModal,
-        handleActivateClick,
-        handleDeleteClick,
-        activating,
+        deleteConfigByName,
         deleting,
         selectedTargetConfigName,
-        canActivateConfig,
-        canDeleteConfig,
     };
 }

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
@@ -1,24 +1,47 @@
-import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
 import { message } from 'antd';
-import { useRosConnection } from '../../../hooks/useRosConnection.hook.ts';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useActiveHardwareRos } from '../../../contexts/ActiveHardwareRosContext.tsx';
+import { useRosConnection } from '../../../hooks/useRosConnection.hook.ts';
+import { boardsToFlashGoal } from '../utils/boardsToFlashGoal.ts';
+import { useActivateConfigureWorkflow } from './useActivateConfigureWorkflow.tsx';
 import { useHardwareConfigEditor } from './useHardwareConfigEditor.tsx';
 import { useHardwareConfigLists } from './useHardwareConfigLists.ts';
 
-export function useHardwareConfiguration(modal: Pick<ModalStaticFunctions, 'confirm'>) {
+export function useHardwareConfiguration() {
     const { isConnected } = useRosConnection();
     const {
         activeHardwareDoc,
         activeHardwareConfigName,
         activeHardwareFetchEpoch,
         refetchActiveHardware,
+        serverRobotPackage,
+        recordServerRobotPackage,
+        serverFlashedConfigName,
+        serverFlashedAt,
+        recordServerFlashedMeta,
     } = useActiveHardwareRos();
     const [messageApi, contextHolderMessage] = message.useMessage();
 
+    const [activateModalOpen, setActivateModalOpen] = useState(false);
+    const [activateModalBoards, setActivateModalBoards] = useState<string[]>([]);
+    const [activateModalBuildOnly, setActivateModalBuildOnlyInner] = useState(false);
+    const [activateModalActivateOnly, setActivateModalActivateOnlyInner] = useState(false);
+
+    const setActivateModalBuildOnly = useCallback((v: boolean) => {
+        setActivateModalBuildOnlyInner(v);
+        if (v) setActivateModalActivateOnlyInner(false);
+    }, []);
+
+    const setActivateModalActivateOnly = useCallback((v: boolean) => {
+        setActivateModalActivateOnlyInner(v);
+        if (v) setActivateModalBuildOnlyInner(false);
+    }, []);
+
     const lists = useHardwareConfigLists(isConnected, messageApi);
     const editor = useHardwareConfigEditor({
-        modal,
         messageApi,
+        recordServerRobotPackage,
+        recordServerFlashedMeta,
         refreshSavedConfigs: lists.refreshSavedConfigs,
         serverActiveConfigName: lists.serverActiveConfigName,
         activeHardwareDoc,
@@ -27,11 +50,124 @@ export function useHardwareConfiguration(modal: Pick<ModalStaticFunctions, 'conf
         refetchActiveHardware,
     });
 
+    const pipelineBoardIds = useMemo(
+        () => editor.boardRows.map((r) => r.boardId),
+        [editor.boardRows],
+    );
+
+    const pipelineBoardOptions = useMemo(
+        () => pipelineBoardIds.map((id) => ({ label: id, value: id })),
+        [pipelineBoardIds],
+    );
+
+    const {
+        workflowRunning,
+        workflowSteps,
+        workflowOverallPercent,
+        workflowDetailLine,
+        runActivateWorkflow,
+        abortWorkflow,
+        resetWorkflowPresentation,
+    } = useActivateConfigureWorkflow({
+        messageApi,
+        isConnected,
+        robotPackageName: serverRobotPackage,
+        refetchActiveHardware,
+    });
+
+    useEffect(() => {
+        if (!activateModalOpen) return;
+        resetWorkflowPresentation(activateModalBuildOnly, activateModalActivateOnly);
+    }, [
+        activateModalOpen,
+        activateModalBuildOnly,
+        activateModalActivateOnly,
+        resetWorkflowPresentation,
+    ]);
+
+    /** Empty board checkbox selection must not mean “flash everything” — force ACTIVATE ONLY. */
+    useEffect(() => {
+        if (!activateModalOpen || workflowRunning) return;
+        if (pipelineBoardIds.length === 0 || activateModalBoards.length > 0) return;
+        setActivateModalActivateOnly(true);
+    }, [
+        activateModalOpen,
+        workflowRunning,
+        pipelineBoardIds.length,
+        activateModalBoards.length,
+        setActivateModalActivateOnly,
+    ]);
+
+    const openActivateModal = useCallback(() => {
+        setActivateModalBoards([...pipelineBoardIds]);
+        setActivateModalBuildOnlyInner(false);
+        setActivateModalActivateOnlyInner(false);
+        resetWorkflowPresentation(false, false);
+        setActivateModalOpen(true);
+    }, [pipelineBoardIds, resetWorkflowPresentation]);
+
+    const closeActivateModal = useCallback(() => {
+        if (workflowRunning) return;
+        setActivateModalOpen(false);
+    }, [workflowRunning]);
+
+    const runWorkflowFromModal = useCallback(async () => {
+        const name = editor.loadConfigName.trim();
+        if (!name) return;
+        const flashBoards = boardsToFlashGoal(activateModalBoards, pipelineBoardIds);
+        const noBoardsSelected = pipelineBoardIds.length > 0 && activateModalBoards.length === 0;
+        await runActivateWorkflow({
+            targetConfigName: name,
+            boardsToFlash: flashBoards,
+            buildOnly: activateModalBuildOnly,
+            activateOnly: activateModalActivateOnly || noBoardsSelected,
+            refreshSavedConfigs: editor.refreshConfigListForModal,
+        });
+    }, [
+        activateModalBoards,
+        activateModalActivateOnly,
+        activateModalBuildOnly,
+        editor.loadConfigName,
+        editor.refreshConfigListForModal,
+        pipelineBoardIds,
+        runActivateWorkflow,
+    ]);
+
+    const modalCanRun =
+        Boolean(editor.selectedTargetConfigName.trim()) &&
+        Boolean(serverRobotPackage.trim()) &&
+        (pipelineBoardIds.length === 0 ||
+            activateModalBoards.length > 0 ||
+            activateModalActivateOnly);
+
+    const editorLocked = workflowRunning;
+
     return {
         contextHolderMessage,
         savedConfigNames: lists.savedConfigNames,
         serverActiveConfigName: lists.serverActiveConfigName,
         configListLoading: lists.configListLoading,
+        serverRobotPackage,
+        activateModalOpen,
+        activateModalBoards,
+        setActivateModalBoards,
+        activateModalBuildOnly,
+        setActivateModalBuildOnly,
+        activateModalActivateOnly,
+        setActivateModalActivateOnly,
+        openActivateModal,
+        closeActivateModal,
+        runWorkflowFromModal,
+        abortWorkflow,
+        workflowRunning,
+        workflowSteps,
+        workflowOverallPercent,
+        workflowDetailLine,
+        modalCanRun,
+        pipelineBoardOptions,
+        editorLocked,
+        serverFlashedConfigName,
+        serverFlashedAt,
         ...editor,
     };
 }

--- a/src/features/hardwareConfiguration/hooks/useHardwareYamlEditorState.ts
+++ b/src/features/hardwareConfiguration/hooks/useHardwareYamlEditorState.ts
@@ -8,7 +8,7 @@ export interface HardwareYamlEditorStateParams {
 }
 
 /**
- * Working copy of the hardware YAML, load/save lifecycle flags, and validation metadata from the server.
+ * Working copy of the hardware YAML, load/save lifecycle flags, and validation metadata from the system.
  */
 export function useHardwareYamlEditorState({
     isConnected,

--- a/src/features/hardwareConfiguration/model/outline.ts
+++ b/src/features/hardwareConfiguration/model/outline.ts
@@ -1,10 +1,10 @@
-import { UI_BORDER_MUTED, UI_ERROR_RED } from '../../../Constants/uiTheme';
+import { UI_BORDER_MUTED, UI_ERROR_RED, uiErrorRgba } from '../../../Constants/uiTheme.ts';
 import type { OutlineBorderSet } from '../../../Utils/hardwareConfigServerErrors.ts';
 
 export function hardwareOutlineBorders(): OutlineBorderSet {
     return {
         ok: `1px solid ${UI_BORDER_MUTED}`,
         exact: `1px solid ${UI_ERROR_RED}`,
-        row: '1px solid rgba(255, 77, 79, 0.45)',
+        row: `1px solid ${uiErrorRgba(0.45)}`,
     };
 }

--- a/src/features/hardwareConfiguration/utils/boardsToFlashGoal.ts
+++ b/src/features/hardwareConfiguration/utils/boardsToFlashGoal.ts
@@ -1,0 +1,12 @@
+/** Maps modal selection to ConfigurePipeline.boards_to_flash ([] = all boards on the system). */
+export function boardsToFlashGoal(selected: readonly string[], allBoardIds: readonly string[]): string[] {
+    const allSorted = [...allBoardIds].sort();
+    const selSorted = [...new Set(selected)].sort();
+    if (allSorted.length === 0) {
+        return [];
+    }
+    if (selSorted.length === allSorted.length && selSorted.every((id, i) => id === allSorted[i])) {
+        return [];
+    }
+    return selSorted;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
+import { mountUiThemeCssVars, UI_BG_BLACK } from './Constants/uiTheme.ts'
+
+mountUiThemeCssVars()
+document.body.style.backgroundColor = UI_BG_BLACK
 
 const rootElement = document.getElementById('root');
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
         ? { protocol: "wss", clientPort: parseInt(env.VITE_PORT || "5000") }
         : undefined,
       proxy: {
-        // Proxy WS upgrades from the browser path /rosbridge -> rosbridge ws server
+        // Proxy WS upgrades from the browser path /rosbridge -> local rosbridge
         '^/rosbridge': {
           target: 'ws://127.0.0.1:9090',
           ws: true,


### PR DESCRIPTION
Issue: https://github.com/Sentience-Robotics/lucy_ros2/issues/105

### PR summary

**Activate workflow & configure-pipeline**

- **Dry run then activate:** The modal runs **`ConfigurePipeline`** with **`dry_run: true`** against the **TARGET** preset (`mapping_file` = target name) for validation/generate feedback only.
- **Wet run on active:** After **`/config/activate`** promotes the target to **active**, the workflow starts **`ConfigurePipeline`** again with **`mapping_file: ''`** (active YAML on disk), **`dry_run: false`**, **`boards_to_flash`** from the modal, and **`build_only`** from **BUILD ONLY**.
- **ACTIVATE ONLY:** Skips build/flash entirely after **`/config/activate`** and refreshes config/active state.
- **Board selection:** Empty selection no longer maps to “flash all boards”; it **forces ACTIVATE ONLY** and guards **`runActivateWorkflow`** so build/flash never runs without an explicit board selection when boards exist.
- **Mutual exclusion:** **BUILD ONLY** and **ACTIVATE ONLY** clear each other when one is turned on; switches stay enabled unless the workflow is running (no cross-disabling).

**Pipeline / robot metadata (related)**

- After a **successful flash** (non-empty flashed boards), **`active_meta.yaml`** records **`flashed_name`** / **`flashed_at`**; **`GetConfig`** returns **`flashed_config_name`** / **`flashed_at`** for the UI **FLASHED** tag.