### PR TITLE
feat(lcp): SIMULATION ONLY workflow, Gazebo-restart prompt, page caching & branded loader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { ConfigProvider, theme, Spin } from 'antd';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { ConfigProvider, theme } from 'antd';
+import { BrowserRouter as Router, useLocation } from 'react-router-dom';
 import { useState, useEffect, lazy, Suspense } from 'react';
+import type { CSSProperties, FC } from 'react';
 /* Pages */
 import { RobotControlPanel } from './Pages/RobotControlPanel';
 import { Navigation } from './Components/Navigation';
@@ -8,6 +9,7 @@ import { NotFound } from './Pages/NotFound';
 import { ActiveHardwareRosProvider } from './contexts/ActiveHardwareRosContext';
 /* Components */
 import { AuthForm } from './Components/AuthForm';
+import { LucyLoader } from './Components/LucyLoader';
 import {
     UI_ACCENT_GREEN,
     UI_BG_BLACK,
@@ -20,6 +22,71 @@ import {
 
 const Robot3DViewer = lazy(() => import('./Pages/Robot3DViewer').then(module => ({ default: module.default })));
 const Configuration = lazy(() => import('./Pages/Configuration').then(module => ({ default: module.default })));
+
+const CONTROL_PATH = '/';
+const CONFIG_PATH = '/configuration';
+const VIEWER_PATH = '/3d-viewer';
+const KNOWN_PATHS = new Set<string>([CONTROL_PATH, CONFIG_PATH, VIEWER_PATH]);
+
+/**
+ * Render all main pages once and toggle visibility with `display: none`.
+ * Keeps page-local state (sliders, edits, expanded panels) alive when the
+ * user switches between CONTROL / CONFIGURATION / 3D VIEW. Lazy pages are
+ * only mounted after their first visit so the initial chunk stays small.
+ */
+const PersistentPages: FC = () => {
+    const { pathname } = useLocation();
+    const [configVisited, setConfigVisited] = useState(false);
+    const [viewerVisited, setViewerVisited] = useState(false);
+
+    useEffect(() => {
+        if (pathname === CONFIG_PATH) setConfigVisited(true);
+        if (pathname === VIEWER_PATH) setViewerVisited(true);
+    }, [pathname]);
+
+    const isKnown = KNOWN_PATHS.has(pathname);
+
+    const pageStyle = (active: boolean): CSSProperties => ({
+        display: active ? 'block' : 'none',
+    });
+
+    return (
+        <>
+            <div style={pageStyle(pathname === CONTROL_PATH)}>
+                <RobotControlPanel />
+            </div>
+            {configVisited ? (
+                <div style={pageStyle(pathname === CONFIG_PATH)}>
+                    <Suspense
+                        fallback={
+                            <LucyLoader
+                                label="LOADING CONFIGURATION"
+                                detail="Preparing the hardware configuration page."
+                            />
+                        }
+                    >
+                        <Configuration />
+                    </Suspense>
+                </div>
+            ) : null}
+            {viewerVisited ? (
+                <div style={pageStyle(pathname === VIEWER_PATH)}>
+                    <Suspense
+                        fallback={
+                            <LucyLoader
+                                label="LOADING 3D VIEW"
+                                detail="Initialising the robot 3D viewer."
+                            />
+                        }
+                    >
+                        <Robot3DViewer />
+                    </Suspense>
+                </div>
+            ) : null}
+            {!isKnown ? <NotFound /> : null}
+        </>
+    );
+};
 
 function App() {
     const localPassword: string | undefined = import.meta.env.VITE_LOCAL_PASSWORD;
@@ -106,21 +173,8 @@ function App() {
         >
             <Router>
                 <ActiveHardwareRosProvider>
-                <Navigation />
-                <Routes>
-                    <Route path="/" element={<RobotControlPanel />} />
-                    <Route path="/3d-viewer" element={
-                        <Suspense fallback={<Spin size="large" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }} />}>
-                            <Robot3DViewer />
-                        </Suspense>
-                    } />
-                    <Route path="/configuration" element={
-                        <Suspense fallback={<Spin size="large" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }} />}>
-                            <Configuration />
-                        </Suspense>
-                    } />
-<Route path="*" element={<NotFound />} />
-                </Routes>
+                    <Navigation />
+                    <PersistentPages />
                 </ActiveHardwareRosProvider>
             </Router>
         </ConfigProvider>

--- a/src/Components/HardwareYamlConfigManager.tsx
+++ b/src/Components/HardwareYamlConfigManager.tsx
@@ -216,9 +216,10 @@ export const HardwareYamlConfigManager: React.FC<HardwareYamlConfigManagerProps>
                 style={{ top: 100 }}
                 styles={modalStyles}
                 className="dark-modal"
+                destroyOnClose
             >
                 <Space direction="vertical" style={{ width: '100%' }} size="large">
-                    {!isDirty ? (
+                    {!isDirty && !saving ? (
                         <Text type="warning">NOTHING TO SAVE — MAKE EDITS FIRST.</Text>
                     ) : null}
 

--- a/src/Components/LucyControlPanelHeader.tsx
+++ b/src/Components/LucyControlPanelHeader.tsx
@@ -256,7 +256,11 @@ export const LucyControlPanelHeader: React.FC<LucyControlPanelHeaderProps> = ({ 
             {connectionError ? (
                 <Alert
                     message="CONNECTION ERROR"
-                    description={connectionError}
+                    description={
+                        <div style={{ whiteSpace: 'pre-line', fontFamily: 'monospace' }}>
+                            {connectionError}
+                        </div>
+                    }
                     type="error"
                     showIcon
                     closable

--- a/src/Components/LucyLoader.css
+++ b/src/Components/LucyLoader.css
@@ -1,0 +1,105 @@
+.lucy-loader {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: 32px 16px;
+    gap: 24px;
+    user-select: none;
+}
+
+.lucy-loader-compact {
+    min-height: 200px;
+}
+
+.lucy-loader-rings {
+    position: relative;
+    width: 96px;
+    height: 96px;
+}
+
+.lucy-loader-ring {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    box-sizing: border-box;
+}
+
+.lucy-loader-ring-outer {
+    border-top-color: var(--lucy-loader-accent);
+    border-right-color: var(--lucy-loader-accent-soft);
+    animation: lucy-loader-spin 1.6s linear infinite;
+    box-shadow: 0 0 18px var(--lucy-loader-accent-glow);
+}
+
+.lucy-loader-ring-middle {
+    inset: 12px;
+    width: auto;
+    height: auto;
+    border-bottom-color: var(--lucy-loader-accent);
+    border-left-color: var(--lucy-loader-accent-soft);
+    animation: lucy-loader-spin-reverse 2.2s linear infinite;
+}
+
+.lucy-loader-ring-inner {
+    inset: 24px;
+    width: auto;
+    height: auto;
+    border-top-color: var(--lucy-loader-accent-soft);
+    border-bottom-color: var(--lucy-loader-accent);
+    animation: lucy-loader-spin 1.2s linear infinite;
+}
+
+.lucy-loader-core {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    margin: -6px 0 0 -6px;
+    border-radius: 50%;
+    background: var(--lucy-loader-accent);
+    box-shadow: 0 0 14px var(--lucy-loader-accent-glow);
+    animation: lucy-loader-pulse 1.4s ease-in-out infinite;
+}
+
+.lucy-loader-text {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+@keyframes lucy-loader-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes lucy-loader-spin-reverse {
+    from {
+        transform: rotate(360deg);
+    }
+    to {
+        transform: rotate(0deg);
+    }
+}
+
+@keyframes lucy-loader-pulse {
+    0%,
+    100% {
+        opacity: 0.55;
+        transform: scale(0.85);
+    }
+    50% {
+        opacity: 1;
+        transform: scale(1.15);
+    }
+}

--- a/src/Components/LucyLoader.tsx
+++ b/src/Components/LucyLoader.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Typography } from 'antd';
+import {
+    UI_ACCENT_GREEN,
+    UI_TEXT_PRIMARY_ON_DARK,
+    UI_TEXT_SUBTLE,
+    uiAccentRgba,
+} from '../Constants/uiTheme.ts';
+import './LucyLoader.css';
+
+const { Text } = Typography;
+
+export interface LucyLoaderProps {
+    /** Big title shown under the spinner (defaults to "LUCY"). */
+    title?: string;
+    /** Status line below the title (e.g. "Connecting to ROS bridge"). */
+    label?: string;
+    /** Optional supporting message, shown smaller below the label. */
+    detail?: string;
+    /** Compact = no full-viewport min-height (use inside cards). */
+    compact?: boolean;
+}
+
+/**
+ * Animated Lucy loader: a triple-ring spinner around the brand mark.
+ *
+ * Used in place of static "Connect to ROS" messages while a page is waiting on
+ * the ROS bridge or the active hardware config.
+ */
+export const LucyLoader: React.FC<LucyLoaderProps> = ({
+    title = 'LUCY',
+    label,
+    detail,
+    compact = false,
+}) => {
+    return (
+        <div className={`lucy-loader${compact ? ' lucy-loader-compact' : ''}`}>
+            <div
+                className="lucy-loader-rings"
+                style={
+                    {
+                        '--lucy-loader-accent': UI_ACCENT_GREEN,
+                        '--lucy-loader-accent-soft': uiAccentRgba(0.25),
+                        '--lucy-loader-accent-glow': uiAccentRgba(0.45),
+                    } as React.CSSProperties
+                }
+                aria-hidden
+            >
+                <span className="lucy-loader-ring lucy-loader-ring-outer" />
+                <span className="lucy-loader-ring lucy-loader-ring-middle" />
+                <span className="lucy-loader-ring lucy-loader-ring-inner" />
+                <span className="lucy-loader-core" />
+            </div>
+            <div className="lucy-loader-text">
+                <Text
+                    strong
+                    style={{
+                        color: UI_TEXT_PRIMARY_ON_DARK,
+                        fontSize: 18,
+                        letterSpacing: 4,
+                    }}
+                >
+                    {title}
+                </Text>
+                {label ? (
+                    <Text
+                        style={{
+                            color: UI_ACCENT_GREEN,
+                            fontSize: 13,
+                            letterSpacing: 2,
+                            marginTop: 4,
+                        }}
+                    >
+                        {label}
+                    </Text>
+                ) : null}
+                {detail ? (
+                    <Text
+                        style={{
+                            color: UI_TEXT_SUBTLE,
+                            fontSize: 12,
+                            marginTop: 6,
+                            maxWidth: 360,
+                            textAlign: 'center',
+                        }}
+                    >
+                        {detail}
+                    </Text>
+                ) : null}
+            </div>
+        </div>
+    );
+};
+
+export default LucyLoader;

--- a/src/Constants/hardwareConfigTypes.ts
+++ b/src/Constants/hardwareConfigTypes.ts
@@ -53,6 +53,7 @@ export interface ConfigurePipelineGoalInput {
     boards_to_flash: string[];
     dry_run: boolean;
     build_only: boolean;
+    simulation_only?: boolean;
 }
 
 export interface ConfigurePipelineFeedbackNormalized {

--- a/src/Constants/rosConfig.ts
+++ b/src/Constants/rosConfig.ts
@@ -35,6 +35,12 @@ export const STREAM_SOURCES: StreamSource[] = [
         messageType: 'sensor_msgs/msg/CompressedImage'
     },
     {
+        id: 'gazebo',
+        name: 'Gazebo Webcam',
+        topic: '/camera/gazebo/compressed',
+        messageType: 'sensor_msgs/msg/CompressedImage'
+    },
+    {
         id: 'realsense-rgb',
         name: 'Realsense RGB',
         topic: '/realsense/realsense2_camera/color/image_raw/compressed',

--- a/src/Pages/RobotControlPanel.tsx
+++ b/src/Pages/RobotControlPanel.tsx
@@ -47,6 +47,7 @@ import { degreeToRadian } from '../Utils/math.utils';
 
 /* Components */
 import { Page } from '../Components/Page';
+import { LucyLoader } from '../Components/LucyLoader';
 import { JointCategory } from '../Components/JointCategory';
 import { DraggableCategory } from '../Components/DraggableCategory';
 import { PoseManager } from '../Components/PoseManager';
@@ -487,18 +488,13 @@ export const RobotControlPanel: React.FC = () => {
             removeScrollbars={false}
         >
             {!isConnected ? (
-                <Alert
-                    type="info"
-                    showIcon
-                    message={
-                        isConnecting ? 'Connecting to ROS bridge…' : 'Connect to ROS bridge'
-                    }
-                    description={
+                <LucyLoader
+                    label={isConnecting ? 'CONNECTING TO ROS BRIDGE' : 'WAITING FOR ROS BRIDGE'}
+                    detail={
                         isConnecting
                             ? 'Joint controls appear after the connection is established and the active hardware configuration is loaded.'
-                            : 'Use CONNECT in the header'
+                            : 'Use CONNECT in the header to start the link.'
                     }
-                    style={{ marginBottom: 12 }}
                 />
             ) : (
                 <>

--- a/src/Services/ros/handlers/ConfigurePipeline.handler.ts
+++ b/src/Services/ros/handlers/ConfigurePipeline.handler.ts
@@ -170,6 +170,7 @@ export function startConfigurePipeline(
         boards_to_flash: input.boards_to_flash,
         dry_run: input.dry_run,
         build_only: input.build_only,
+        simulation_only: input.simulation_only ?? false,
     };
 
     let settled = false;

--- a/src/Services/ros/handlers/GazeboStatus.handler.ts
+++ b/src/Services/ros/handlers/GazeboStatus.handler.ts
@@ -1,0 +1,86 @@
+import ROSLIB from 'roslib';
+import { RosBridgeService } from '../ros.service.ts';
+
+/**
+ * Subscribes to the latched `/lucy/gazebo_running` topic published by
+ * `lucy_control_supervisor` (`std_msgs/Bool`, transient_local QoS).
+ *
+ *  - `true`  → Gazebo is part of the active launch graph.
+ *  - `false` → supervisor running, Gazebo is not (e.g. RViz-only / real hardware).
+ *  - `null`  → no value received yet (either disconnected or supervisor not up).
+ */
+const GAZEBO_RUNNING_TOPIC = '/lucy/gazebo_running';
+
+type Listener = (value: boolean | null) => void;
+
+export class GazeboStatusHandler {
+    private static _instance: GazeboStatusHandler | null = null;
+
+    private topic: ROSLIB.Topic | null = null;
+    private unsubscribeStatus: (() => void) | null = null;
+    private listeners: Set<Listener> = new Set();
+    private _value: boolean | null = null;
+
+    private constructor() {
+        this.unsubscribeStatus = RosBridgeService.getInstance().onStatusChange((status) => {
+            if (status === 'connected') {
+                this.initTopic();
+            } else if (status === 'disconnected') {
+                this.topic?.unsubscribe();
+                this.topic = null;
+                this.setValue(null);
+            }
+        });
+        if (RosBridgeService.getInstance().isConnected) {
+            this.initTopic();
+        }
+    }
+
+    static getInstance(): GazeboStatusHandler {
+        if (!GazeboStatusHandler._instance) {
+            GazeboStatusHandler._instance = new GazeboStatusHandler();
+        }
+        return GazeboStatusHandler._instance;
+    }
+
+    get value(): boolean | null {
+        return this._value;
+    }
+
+    subscribe(cb: Listener): () => void {
+        this.listeners.add(cb);
+        cb(this._value);
+        return () => {
+            this.listeners.delete(cb);
+        };
+    }
+
+    private setValue(v: boolean | null) {
+        if (v === this._value) return;
+        this._value = v;
+        this.listeners.forEach((cb) => cb(v));
+    }
+
+    private initTopic() {
+        const ros = RosBridgeService.getInstance().rosConnection;
+        if (!ros) return;
+        this.topic?.unsubscribe();
+        this.topic = new ROSLIB.Topic({
+            ros,
+            name: GAZEBO_RUNNING_TOPIC,
+            messageType: 'std_msgs/msg/Bool',
+        });
+        this.topic.subscribe((msg: ROSLIB.Message) => {
+            const data = (msg as unknown as { data?: boolean }).data;
+            this.setValue(Boolean(data));
+        });
+    }
+
+    static cleanup() {
+        if (GazeboStatusHandler._instance) {
+            GazeboStatusHandler._instance.topic?.unsubscribe();
+            GazeboStatusHandler._instance.unsubscribeStatus?.();
+            GazeboStatusHandler._instance = null;
+        }
+    }
+}

--- a/src/Services/ros/ros.service.ts
+++ b/src/Services/ros/ros.service.ts
@@ -5,6 +5,30 @@ import { logger } from "../../Utils/logger.utils.ts";
 
 export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected';
 
+/**
+ * roslib forwards the raw websocket `error` Event when the bridge is
+ * unreachable, which stringifies as "[object Event]" — useless for users.
+ * Turn it into actionable guidance that points at the Lucy bringup launch.
+ */
+function describeRosBridgeFailure(error: unknown, url: string, opts?: { timeout?: boolean }): string {
+    const detail = (() => {
+        if (opts?.timeout) return `timed out after ${RosBridgeService.CONNECTION_TIMEOUT_MS / 1000}s`;
+        if (error instanceof Error) return error.message;
+        if (typeof error === 'string') return error;
+        if (error && typeof error === 'object' && 'type' in error) {
+            const evt = error as Event;
+            return evt.type === 'error' ? 'WebSocket error' : evt.type;
+        }
+        return '';
+    })();
+    const suffix = detail ? ` (${detail})` : '';
+    return [
+        `Could not reach the ROS bridge at ${url}${suffix}.`,
+        'Launch lucy bringup first:',
+        'ros2 launch lucy_bringup lucy.launch.py gazebo:=true rviz:=true',
+    ].join('\n');
+}
+
 class RosBridgeService {
     private static instance: RosBridgeService;
     private ros: ROSLIB.Ros | null = null;
@@ -12,7 +36,8 @@ class RosBridgeService {
     private url: string = '';
     private connectionTimeout: NodeJS.Timeout | null = null;
     private statusListeners: ((status: ConnectionStatus) => void)[] = [];
-    private readonly CONNECTION_TIMEOUT_MS = 10000; // 10 seconds
+    private pendingConnectReject: ((reason: Error) => void) | null = null;
+    static readonly CONNECTION_TIMEOUT_MS = 10000; // 10 seconds
 
     private setConnectionStatus(status: ConnectionStatus) {
         if (this._connectionStatus !== status) {
@@ -64,7 +89,13 @@ class RosBridgeService {
                 this.ros.close();
                 this.ros = null;
             }
-        }, this.CONNECTION_TIMEOUT_MS);
+            if (this.pendingConnectReject) {
+                this.pendingConnectReject(
+                    new Error(describeRosBridgeFailure(null, this.url, { timeout: true })),
+                );
+                this.pendingConnectReject = null;
+            }
+        }, RosBridgeService.CONNECTION_TIMEOUT_MS);
     }
 
     static getInstance(): RosBridgeService {
@@ -118,16 +149,22 @@ class RosBridgeService {
             try {
                 this.ros = this.createConnection();
 
-                const onConnect = () => {
+                const cleanup = () => {
                     this.ros?.off('connection', onConnect);
                     this.ros?.off('error', onError);
+                    this.pendingConnectReject = null;
+                };
+                const onConnect = () => {
+                    cleanup();
                     resolve();
                 };
-
                 const onError = (error: any) => {
-                    this.ros?.off('connection', onConnect);
-                    this.ros?.off('error', onError);
-                    reject(new Error(`Failed to connect: ${error}`));
+                    cleanup();
+                    reject(new Error(describeRosBridgeFailure(error, this.url)));
+                };
+                this.pendingConnectReject = (reason: Error) => {
+                    cleanup();
+                    reject(reason);
                 };
 
                 this.ros.on('connection', onConnect);
@@ -135,7 +172,8 @@ class RosBridgeService {
             } catch (error) {
                 this.clearConnectionTimeout();
                 this.setConnectionStatus('disconnected');
-                reject(error);
+                this.pendingConnectReject = null;
+                reject(error instanceof Error ? error : new Error(describeRosBridgeFailure(error, this.url)));
             }
         });
     }
@@ -146,6 +184,7 @@ class RosBridgeService {
             this.ros.close();
             this.ros = null;
         }
+        this.pendingConnectReject = null;
         this.setConnectionStatus('disconnected');
     }
 }

--- a/src/features/hardwareConfiguration/ConfigurationPage.tsx
+++ b/src/features/hardwareConfiguration/ConfigurationPage.tsx
@@ -210,6 +210,8 @@ const ConfigurationPage = () => {
                 onActivateModalBuildOnlyChange={hw.setActivateModalBuildOnly}
                 activateModalActivateOnly={hw.activateModalActivateOnly}
                 onActivateModalActivateOnlyChange={hw.setActivateModalActivateOnly}
+                activateModalSimulationOnly={hw.activateModalSimulationOnly}
+                onActivateModalSimulationOnlyChange={hw.setActivateModalSimulationOnly}
                 onRun={hw.runWorkflowFromModal}
                 onAbort={hw.abortWorkflow}
                 workflowRunning={hw.workflowRunning}

--- a/src/features/hardwareConfiguration/ConfigurationPage.tsx
+++ b/src/features/hardwareConfiguration/ConfigurationPage.tsx
@@ -218,6 +218,9 @@ const ConfigurationPage = () => {
                 workflowSteps={hw.workflowSteps}
                 workflowOverallPercent={hw.workflowOverallPercent}
                 workflowDetailLine={hw.workflowDetailLine}
+                workflowLastRunSucceeded={hw.workflowLastRunSucceeded}
+                workflowLastRunDiff={hw.workflowLastRunDiff}
+                gazeboRunning={hw.gazeboRunning}
                 canRun={hw.modalCanRun && hw.isConnected}
             />
 

--- a/src/features/hardwareConfiguration/ConfigurationPage.tsx
+++ b/src/features/hardwareConfiguration/ConfigurationPage.tsx
@@ -4,6 +4,7 @@ import { Page } from '../../Components/Page.tsx';
 import { HardwareConfigPresetHeaderTag } from '../../Components/HardwareConfigPresetTag.tsx';
 import { HardwareYamlConfigManager } from '../../Components/HardwareYamlConfigManager.tsx';
 import { LucyControlPanelHeader } from '../../Components/LucyControlPanelHeader.tsx';
+import { LucyLoader } from '../../Components/LucyLoader.tsx';
 import { UNPARSED_VALIDATION_KEY, GENERAL_VALIDATION_KEY } from '../../Utils/hardwareConfigServerErrors.ts';
 import { UI_CARD_SURFACE_STYLE, UI_PRIMARY_GREEN_BUTTON_STYLE } from '../../Constants/uiTheme.ts';
 import './configuration.switch.css';
@@ -136,14 +137,13 @@ const ConfigurationPage = () => {
             </div>
 
             {!hw.yamlDoc ? (
-                <Alert
-                    type="info"
-                    message={
+                <LucyLoader
+                    label={hw.loading ? 'LOADING HARDWARE CONFIGURATION' : 'WAITING FOR ROS BRIDGE'}
+                    detail={
                         hw.loading
-                            ? 'LOADING HARDWARE CONFIGURATION…'
-                            : 'CONNECT TO ROS SYSTEM FIRST'
+                            ? 'Fetching the active hardware preset and joint catalog.'
+                            : 'Use CONNECT in the header — the configuration loads automatically once linked.'
                     }
-                    showIcon
                 />
             ) : null}
 

--- a/src/features/hardwareConfiguration/activateWorkflowStepTypes.ts
+++ b/src/features/hardwareConfiguration/activateWorkflowStepTypes.ts
@@ -1,4 +1,4 @@
-export type WorkflowStepId = 'validate' | 'activate' | 'build' | 'flash';
+export type WorkflowStepId = 'validate' | 'activate' | 'build' | 'flash' | 'reload';
 
 export type WorkflowStepRuntimeStatus = 'pending' | 'running' | 'done' | 'error' | 'skipped';
 

--- a/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
+++ b/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
@@ -374,10 +374,6 @@ function GazeboRestartDiffBody({ diff }: { diff: HardwareConfigDiff }) {
     const noun = (n: number, s: string) => `${n} ${s}${n === 1 ? '' : 's'}`;
     return (
         <Space direction="vertical" size={6} style={{ width: '100%' }}>
-            <Text style={{ fontSize: 12 }}>
-                gz_ros2_control loads the URDF + ros2_control blocks at robot spawn. To apply the
-                new xacro, restart Lucy with Gazebo using one of the following:
-            </Text>
             <div style={{ fontSize: 12 }}>
                 <Text strong>Recommended:</Text>{' '}
                 <Text>

--- a/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
+++ b/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
@@ -4,8 +4,10 @@ import {
     LoadingOutlined,
     MinusCircleOutlined,
     ThunderboltOutlined,
+    WarningOutlined,
 } from '@ant-design/icons';
-import { Button, Card, Checkbox, Divider, Modal, Progress, Space, Switch, Typography } from 'antd';
+import { Alert, Button, Card, Checkbox, Divider, Modal, Progress, Space, Switch, Tag, Typography } from 'antd';
+import type { HardwareConfigDiff } from '../model/hardwareConfigDiff.ts';
 import { HardwareConfigPresetHeaderTag } from '../../../Components/HardwareConfigPresetTag.tsx';
 import {
     UI_ACCENT_GREEN,
@@ -70,6 +72,18 @@ export interface ActivateConfigureWorkflowModalProps {
     workflowSteps: WorkflowStepSlice[];
     workflowOverallPercent: number;
     workflowDetailLine: string;
+    /** True once the most recent run finished successfully (and no new run started). */
+    workflowLastRunSucceeded: boolean;
+    /**
+     * Structural diff between the active doc captured before the run and the
+     * target preset. `null` when not enough info to compute (e.g. server fetch failed).
+     */
+    workflowLastRunDiff: HardwareConfigDiff | null;
+    /**
+     * `true` if Gazebo is part of the active launch graph (latched signal
+     * from `lucy_control_supervisor`). `false` if known not to be. `null` if unknown.
+     */
+    gazeboRunning: boolean | null;
     canRun: boolean;
 }
 
@@ -96,8 +110,25 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
         workflowSteps,
         workflowOverallPercent,
         workflowDetailLine,
+        workflowLastRunSucceeded,
+        workflowLastRunDiff,
+        gazeboRunning,
         canRun,
     } = props;
+
+    const showGazeboRestartPrompt =
+        !workflowRunning &&
+        workflowLastRunSucceeded &&
+        gazeboRunning === true &&
+        workflowLastRunDiff !== null &&
+        workflowLastRunDiff.requiresGazeboRestart;
+
+    const showNoRestartNeeded =
+        !workflowRunning &&
+        workflowLastRunSucceeded &&
+        gazeboRunning === true &&
+        workflowLastRunDiff !== null &&
+        !workflowLastRunDiff.requiresGazeboRestart;
 
     return (
         <Modal
@@ -267,6 +298,27 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                     ) : null}
                 </div>
 
+                {showGazeboRestartPrompt && workflowLastRunDiff ? (
+                    <Alert
+                        type="warning"
+                        showIcon
+                        icon={<WarningOutlined />}
+                        message="GAZEBO RESTART REQUIRED"
+                        description={
+                            <GazeboRestartDiffBody diff={workflowLastRunDiff} />
+                        }
+                    />
+                ) : null}
+
+                {showNoRestartNeeded ? (
+                    <Alert
+                        type="success"
+                        showIcon
+                        message="GAZEBO RESTART NOT REQUIRED"
+                        description="Generated ros2_control xacro is unchanged — RELOAD applied the new controllers."
+                    />
+                ) : null}
+
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 8 }}>
                     {workflowRunning ? (
                         <Button danger onClick={onAbort}>
@@ -276,23 +328,113 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                         <span />
                     )}
                     <Space>
-                        <Button onClick={onClose} disabled={workflowRunning}>
-                            CANCEL
-                        </Button>
-                        {!workflowRunning ? (
-                            <Button
-                                type="primary"
-                                icon={<ThunderboltOutlined />}
-                                onClick={() => void onRun()}
-                                disabled={!canRun}
-                                style={UI_PRIMARY_GREEN_BUTTON_STYLE}
-                            >
-                                RUN
-                            </Button>
-                        ) : null}
+                        {!workflowRunning && workflowLastRunSucceeded ? (
+                            <>
+                                <Button
+                                    danger
+                                    icon={<ThunderboltOutlined />}
+                                    onClick={() => void onRun()}
+                                    disabled={!canRun}
+                                >
+                                    RUN AGAIN
+                                </Button>
+                                <Button
+                                    type="primary"
+                                    onClick={onClose}
+                                    style={UI_PRIMARY_GREEN_BUTTON_STYLE}
+                                >
+                                    DONE
+                                </Button>
+                            </>
+                        ) : (
+                            <>
+                                <Button onClick={onClose} disabled={workflowRunning}>
+                                    CANCEL
+                                </Button>
+                                {!workflowRunning ? (
+                                    <Button
+                                        type="primary"
+                                        icon={<ThunderboltOutlined />}
+                                        onClick={() => void onRun()}
+                                        disabled={!canRun}
+                                        style={UI_PRIMARY_GREEN_BUTTON_STYLE}
+                                    >
+                                        RUN
+                                    </Button>
+                                ) : null}
+                            </>
+                        )}
                     </Space>
                 </div>
             </Space>
         </Modal>
+    );
+}
+
+function GazeboRestartDiffBody({ diff }: { diff: HardwareConfigDiff }) {
+    const noun = (n: number, s: string) => `${n} ${s}${n === 1 ? '' : 's'}`;
+    return (
+        <Space direction="vertical" size={6} style={{ width: '100%' }}>
+            <Text style={{ fontSize: 12 }}>
+                gz_ros2_control loads the URDF + ros2_control blocks at robot spawn. Apply the new
+                xacro by restarting Lucy with Gazebo:
+            </Text>
+            <Text code copyable style={{ fontSize: 11 }}>
+                ros2 launch lucy_bringup lucy.launch.py gazebo:=true rviz:=true
+            </Text>
+            <Divider style={{ margin: '6px 0' }} />
+            <Space size={6} wrap>
+                {diff.boardsAdded.length > 0 ? (
+                    <Tag color="green">+{noun(diff.boardsAdded.length, 'board')}</Tag>
+                ) : null}
+                {diff.boardsRemoved.length > 0 ? (
+                    <Tag color="red">-{noun(diff.boardsRemoved.length, 'board')}</Tag>
+                ) : null}
+                {diff.actuatorsAdded.length > 0 ? (
+                    <Tag color="green">+{noun(diff.actuatorsAdded.length, 'actuator')}</Tag>
+                ) : null}
+                {diff.actuatorsRemoved.length > 0 ? (
+                    <Tag color="red">-{noun(diff.actuatorsRemoved.length, 'actuator')}</Tag>
+                ) : null}
+                {diff.actuatorsModified.length > 0 ? (
+                    <Tag color="orange">
+                        ~{noun(diff.actuatorsModified.length, 'actuator')} modified
+                    </Tag>
+                ) : null}
+            </Space>
+            <div style={{ maxHeight: 180, overflow: 'auto', fontSize: 11, lineHeight: 1.4 }}>
+                {diff.boardsAdded.map((b) => (
+                    <div key={`b+${b}`}>
+                        <Text type="success">+ board {b}</Text>
+                    </div>
+                ))}
+                {diff.boardsRemoved.map((b) => (
+                    <div key={`b-${b}`}>
+                        <Text type="danger">− board {b}</Text>
+                    </div>
+                ))}
+                {diff.actuatorsAdded.map((a) => (
+                    <div key={`a+${a.actuatorId}`}>
+                        <Text type="success">+ actuator {a.label}</Text>
+                    </div>
+                ))}
+                {diff.actuatorsRemoved.map((a) => (
+                    <div key={`a-${a.actuatorId}`}>
+                        <Text type="danger">− actuator {a.label}</Text>
+                    </div>
+                ))}
+                {diff.actuatorsModified.map((a) => (
+                    <div key={`a~${a.actuatorId}`}>
+                        <Text type="warning">~ actuator {a.label}</Text>
+                        <span style={{ color: '#999' }}>
+                            {' '}
+                            {a.changes
+                                .map((c) => `${c.field}: ${String(c.before ?? '∅')} → ${String(c.after ?? '∅')}`)
+                                .join(', ')}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </Space>
     );
 }

--- a/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
+++ b/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
@@ -331,7 +331,6 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                         {!workflowRunning && workflowLastRunSucceeded ? (
                             <>
                                 <Button
-                                    danger
                                     icon={<ThunderboltOutlined />}
                                     onClick={() => void onRun()}
                                     disabled={!canRun}
@@ -376,12 +375,32 @@ function GazeboRestartDiffBody({ diff }: { diff: HardwareConfigDiff }) {
     return (
         <Space direction="vertical" size={6} style={{ width: '100%' }}>
             <Text style={{ fontSize: 12 }}>
-                gz_ros2_control loads the URDF + ros2_control blocks at robot spawn. Apply the new
-                xacro by restarting Lucy with Gazebo:
+                gz_ros2_control loads the URDF + ros2_control blocks at robot spawn. To apply the
+                new xacro, restart Lucy with Gazebo using one of the following:
             </Text>
-            <Text code copyable style={{ fontSize: 11 }}>
-                ros2 launch lucy_bringup lucy.launch.py gazebo:=true rviz:=true
-            </Text>
+            <div style={{ fontSize: 12 }}>
+                <Text strong>Recommended:</Text>{' '}
+                <Text>
+                    press <Text code>Ctrl+C</Text> in the Lucy terminal, close it, then open a new
+                    terminal and run:
+                </Text>
+                <div style={{ marginTop: 4 }}>
+                    <Text code copyable style={{ fontSize: 11 }}>
+                        ./launch_lucy.sh
+                    </Text>
+                </div>
+            </div>
+            <div style={{ fontSize: 12 }}>
+                <Text strong>Advanced (same terminal):</Text>{' '}
+                <Text>
+                    press <Text code>Ctrl+C</Text>, then run:
+                </Text>
+                <div style={{ marginTop: 4 }}>
+                    <Text code copyable style={{ fontSize: 11 }}>
+                        ros2 launch lucy_bringup lucy.launch.py gazebo:=true rviz:=true
+                    </Text>
+                </div>
+            </div>
             <Divider style={{ margin: '6px 0' }} />
             <Space size={6} wrap>
                 {diff.boardsAdded.length > 0 ? (

--- a/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
+++ b/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
@@ -61,6 +61,8 @@ export interface ActivateConfigureWorkflowModalProps {
     onActivateModalBuildOnlyChange: (v: boolean) => void;
     activateModalActivateOnly: boolean;
     onActivateModalActivateOnlyChange: (v: boolean) => void;
+    activateModalSimulationOnly: boolean;
+    onActivateModalSimulationOnlyChange: (v: boolean) => void;
     /** Primary action */
     onRun: () => void | Promise<void>;
     onAbort: () => void;
@@ -86,6 +88,8 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
         onActivateModalBuildOnlyChange,
         activateModalActivateOnly,
         onActivateModalActivateOnlyChange,
+        activateModalSimulationOnly,
+        onActivateModalSimulationOnlyChange,
         onRun,
         onAbort,
         workflowRunning,
@@ -128,6 +132,18 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                 ) : null}
 
                 <div>
+                    <Switch
+                        className="hardware-config-ant-switch"
+                        checked={activateModalSimulationOnly}
+                        onChange={onActivateModalSimulationOnlyChange}
+                        disabled={workflowRunning || pipelineBoardOptions.length === 0}
+                    />
+                    <Text style={{ marginLeft: 8 }}>SIMULATION ONLY (NO HARDWARE BUILD / FLASH)</Text>
+                </div>
+
+                {!activateModalSimulationOnly ? (
+                <>
+                <div>
                     <Text style={{ color: UI_TEXT_SUBTLE, fontSize: 12, marginBottom: 8, display: 'block' }}>
                         BOARDS
                         {pipelineBoardOptions.length > 0 ? (
@@ -156,7 +172,7 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                         onChange={onActivateModalActivateOnlyChange}
                         disabled={workflowRunning}
                     />
-                    <Text style={{ marginLeft: 8 }}>ACTIVATE ONLY (NO BUILD / FLASH)</Text>
+                    <Text style={{ marginLeft: 8 }}>ACTIVATE ONLY (NO BUILD / FLASH / RELOAD)</Text>
                 </div>
                 <div>
                     <Switch
@@ -167,6 +183,8 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                     />
                     <Text style={{ marginLeft: 8 }}>BUILD ONLY (NO FLASH)</Text>
                 </div>
+                </>
+                ) : null}
 
                 <Card size="small" style={{ ...UI_CARD_SURFACE_STYLE }}>
                     <HardwareConfigPresetHeaderTag
@@ -195,12 +213,20 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                     <div
                         style={{
                             display: 'grid',
-                            gridTemplateColumns: 'repeat(4, 1fr)',
+                            gridTemplateColumns: activateModalSimulationOnly
+                                ? 'repeat(3, 1fr)'
+                                : 'repeat(5, 1fr)',
                             gap: 8,
                             marginTop: 12,
                         }}
                     >
-                        {workflowSteps.map((s) => (
+                        {(activateModalSimulationOnly
+                            ? (['validate', 'activate', 'reload'] as const)
+                            : (['validate', 'activate', 'build', 'flash', 'reload'] as const)
+                        )
+                            .map((id) => workflowSteps.find((s) => s.id === id))
+                            .filter((s): s is NonNullable<typeof s> => s != null)
+                            .map((s) => (
                             <Card
                                 key={s.id}
                                 size="small"

--- a/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
+++ b/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
@@ -8,7 +8,32 @@ import type {
     WorkflowStepSlice,
 } from '../activateWorkflowStepTypes.ts';
 
-function initialSteps(buildOnly: boolean, activateOnly: boolean): WorkflowStepSlice[] {
+function initialSteps(
+    simulationOnly: boolean,
+    buildOnly: boolean,
+    activateOnly: boolean,
+): WorkflowStepSlice[] {
+    if (simulationOnly) {
+        return [
+            { id: 'validate', title: 'VALIDATE', status: 'pending', fraction: 0, detail: '' },
+            { id: 'activate', title: 'ACTIVATE', status: 'pending', fraction: 0, detail: '' },
+            { id: 'reload', title: 'RELOAD', status: 'pending', fraction: 0, detail: '' },
+            {
+                id: 'build',
+                title: 'BUILD',
+                status: 'skipped',
+                fraction: 0,
+                detail: 'Skipped (simulation only)',
+            },
+            {
+                id: 'flash',
+                title: 'FLASH',
+                status: 'skipped',
+                fraction: 0,
+                detail: 'Skipped (simulation only)',
+            },
+        ];
+    }
     return [
         { id: 'validate', title: 'VALIDATE', status: 'pending', fraction: 0, detail: '' },
         { id: 'activate', title: 'ACTIVATE', status: 'pending', fraction: 0, detail: '' },
@@ -24,8 +49,13 @@ function initialSteps(buildOnly: boolean, activateOnly: boolean): WorkflowStepSl
             title: 'FLASH',
             status: buildOnly || activateOnly ? 'skipped' : 'pending',
             fraction: 0,
-            detail: buildOnly ? 'Skipped (build only)' : activateOnly ? 'Skipped (activate only)' : '',
+            detail: buildOnly
+                ? 'Skipped (build only)'
+                : activateOnly
+                  ? 'Skipped (activate only)'
+                  : '',
         },
+        { id: 'reload', title: 'RELOAD', status: 'pending', fraction: 0, detail: '' },
     ];
 }
 
@@ -59,6 +89,14 @@ function fractionForValidateDryRun(f: ConfigurePipelineFeedbackNormalized): numb
     return Math.max(0, Math.min(1, f.progress));
 }
 
+function fractionForWetSim(f: ConfigurePipelineFeedbackNormalized): number {
+    const p = f.phase?.toLowerCase() ?? '';
+    if (p === 'validate') return Math.max(0, Math.min(1, f.progress * 0.25));
+    if (p === 'generate') return Math.max(0, Math.min(1, 0.25 + f.progress * 0.35));
+    if (p === 'reload') return Math.max(0, Math.min(1, 0.6 + f.progress * 0.4));
+    return Math.max(0, Math.min(1, f.progress));
+}
+
 export interface UseActivateConfigureWorkflowParams {
     messageApi: MessageInstance;
     isConnected: boolean;
@@ -73,7 +111,7 @@ export function useActivateConfigureWorkflow({
     refetchActiveHardware,
 }: UseActivateConfigureWorkflowParams) {
     const [workflowRunning, setWorkflowRunning] = useState(false);
-    const [steps, setSteps] = useState<WorkflowStepSlice[]>(() => initialSteps(false, false));
+    const [steps, setSteps] = useState<WorkflowStepSlice[]>(() => initialSteps(false, false, false));
     const [detailLine, setDetailLine] = useState('');
     const abortRef = useRef<(() => void) | null>(null);
     const runIdRef = useRef(0);
@@ -85,10 +123,13 @@ export function useActivateConfigureWorkflow({
         abortRef.current = null;
     }, []);
 
-    const resetWorkflowPresentation = useCallback((buildOnly: boolean, activateOnly: boolean) => {
-        setSteps(initialSteps(buildOnly, activateOnly));
-        setDetailLine('');
-    }, []);
+    const resetWorkflowPresentation = useCallback(
+        (simulationOnly: boolean, buildOnly: boolean, activateOnly: boolean) => {
+            setSteps(initialSteps(simulationOnly, buildOnly, activateOnly));
+            setDetailLine('');
+        },
+        [],
+    );
 
     const patchStep = useCallback((id: WorkflowStepId, patch: Partial<Omit<WorkflowStepSlice, 'id' | 'title'>>) => {
         setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)));
@@ -100,9 +141,16 @@ export function useActivateConfigureWorkflow({
             boardsToFlash: string[];
             buildOnly: boolean;
             activateOnly: boolean;
+            simulationOnly: boolean;
             refreshSavedConfigs: () => Promise<unknown>;
         }) => {
-            const { targetConfigName, boardsToFlash, buildOnly, activateOnly } = params;
+            const {
+                targetConfigName,
+                boardsToFlash,
+                buildOnly,
+                activateOnly,
+                simulationOnly,
+            } = params;
             const rp = robotPackageName.trim();
             if (!isConnected) {
                 messageApi.error('Connect to ROS bridge first.');
@@ -120,7 +168,7 @@ export function useActivateConfigureWorkflow({
             const runId = ++runIdRef.current;
             abortRef.current = null;
             setWorkflowRunning(true);
-            setSteps(initialSteps(buildOnly, activateOnly));
+            setSteps(initialSteps(simulationOnly, buildOnly, activateOnly));
             setDetailLine('');
 
             const shouldContinue = () => runId === runIdRef.current;
@@ -143,6 +191,7 @@ export function useActivateConfigureWorkflow({
                         boards_to_flash: boardsToFlash,
                         dry_run: true,
                         build_only: false,
+                        simulation_only: simulationOnly,
                     },
                     {
                         onFeedback: (f) => {
@@ -186,7 +235,7 @@ export function useActivateConfigureWorkflow({
                 await params.refreshSavedConfigs();
                 await refetchActiveHardware();
 
-                if (activateOnly) {
+                if (activateOnly && !simulationOnly) {
                     patchStep('build', {
                         status: 'skipped',
                         fraction: 0,
@@ -197,19 +246,32 @@ export function useActivateConfigureWorkflow({
                         fraction: 0,
                         detail: 'Skipped (activate only)',
                     });
-                    setDetailLine('Activated — build and flash skipped.');
+                    patchStep('reload', {
+                        status: 'skipped',
+                        fraction: 0,
+                        detail: 'Skipped (activate only)',
+                    });
+                    setDetailLine('Activated — build, flash, and reload skipped.');
                     await refetchActiveHardware();
-                    messageApi.success('Configuration activated (build and flash skipped).');
+                    messageApi.success('Configuration activated (build, flash, and reload skipped).');
                     return;
                 }
 
-                patchStep('build', { status: 'running', fraction: 0, detail: '' });
-                if (!buildOnly) {
-                    patchStep('flash', { status: 'pending', fraction: 0, detail: '' });
+                if (!simulationOnly) {
+                    patchStep('build', { status: 'running', fraction: 0, detail: '' });
+                    if (!buildOnly) {
+                        patchStep('flash', { status: 'pending', fraction: 0, detail: '' });
+                    }
                 }
-                setDetailLine('BUILD — pipeline on active mapping…');
+                patchStep('reload', { status: 'pending', fraction: 0, detail: '' });
+                setDetailLine(
+                    simulationOnly
+                        ? 'SIMULATION — generate sim ros2_control and reload…'
+                        : 'BUILD — pipeline on active mapping…',
+                );
 
                 let sawFlash = false;
+                let sawReload = false;
                 const wet = startConfigurePipeline(
                     {
                         robot_package: rp,
@@ -217,6 +279,7 @@ export function useActivateConfigureWorkflow({
                         boards_to_flash: boardsToFlash,
                         dry_run: false,
                         build_only: buildOnly,
+                        simulation_only: simulationOnly,
                     },
                     {
                         onFeedback: (f: ConfigurePipelineFeedbackNormalized) => {
@@ -224,12 +287,37 @@ export function useActivateConfigureWorkflow({
                             const phase = (f.phase || '').toLowerCase();
                             setDetailLine(f.detail || `${phase.toUpperCase()}…`);
 
-                            if (phase === 'flash') {
+                            if (phase === 'reload') {
+                                sawReload = true;
+                                if (!simulationOnly) {
+                                    patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
+                                    if (buildOnly) {
+                                        patchStep('flash', {
+                                            status: 'skipped',
+                                            fraction: 0,
+                                            detail: 'Skipped (build only)',
+                                        });
+                                    } else {
+                                        patchStep('flash', { status: 'done', fraction: 1, detail: 'OK' });
+                                    }
+                                }
+                                patchStep('reload', {
+                                    status: 'running',
+                                    fraction: Math.max(0, Math.min(1, f.progress)),
+                                    detail: f.detail || phase,
+                                });
+                            } else if (phase === 'flash') {
                                 sawFlash = true;
                                 patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
                                 patchStep('flash', {
                                     status: 'running',
                                     fraction: Math.max(0, Math.min(1, f.progress)),
+                                    detail: f.detail || phase,
+                                });
+                            } else if (simulationOnly) {
+                                patchStep('reload', {
+                                    status: 'running',
+                                    fraction: fractionForWetSim(f),
                                     detail: f.detail || phase,
                                 });
                             } else {
@@ -250,21 +338,25 @@ export function useActivateConfigureWorkflow({
 
                 if (!wetRes.success) {
                     const msg = wetRes.message || 'Configure pipeline failed';
-                    if (buildOnly || !sawFlash) failStep('build', msg);
+                    if (simulationOnly && sawReload) failStep('reload', msg);
+                    else if (buildOnly || !sawFlash) failStep('build', msg);
                     else failStep('flash', msg);
                     return;
                 }
 
-                patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
-                if (buildOnly) {
-                    patchStep('flash', {
-                        status: 'skipped',
-                        fraction: 0,
-                        detail: 'Skipped (build only)',
-                    });
-                } else {
-                    patchStep('flash', { status: 'done', fraction: 1, detail: 'OK' });
+                if (!simulationOnly) {
+                    patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
+                    if (buildOnly) {
+                        patchStep('flash', {
+                            status: 'skipped',
+                            fraction: 0,
+                            detail: 'Skipped (build only)',
+                        });
+                    } else {
+                        patchStep('flash', { status: 'done', fraction: 1, detail: 'OK' });
+                    }
                 }
+                patchStep('reload', { status: 'done', fraction: 1, detail: 'OK' });
                 setDetailLine(wetRes.message || 'Complete');
                 await refetchActiveHardware();
                 messageApi.success(`Workflow finished: ${wetRes.message || 'OK'}`);

--- a/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
+++ b/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
@@ -3,10 +3,15 @@ import { useCallback, useRef, useState } from 'react';
 import type { ConfigurePipelineFeedbackNormalized } from '../../../Constants/hardwareConfigTypes.ts';
 import { HardwareConfigHandler } from '../../../Services/ros/handlers/HardwareConfig.handler.ts';
 import { startConfigurePipeline } from '../../../Services/ros/handlers/ConfigurePipeline.handler.ts';
+import { parseHardwareConfigYaml } from '../../../Utils/hardwareConfigYaml.ts';
 import type {
     WorkflowStepId,
     WorkflowStepSlice,
 } from '../activateWorkflowStepTypes.ts';
+import {
+    computeHardwareConfigDiff,
+    type HardwareConfigDiff,
+} from '../model/hardwareConfigDiff.ts';
 
 function initialSteps(
     simulationOnly: boolean,
@@ -102,6 +107,12 @@ export interface UseActivateConfigureWorkflowParams {
     isConnected: boolean;
     robotPackageName: string;
     refetchActiveHardware: () => Promise<unknown>;
+    /**
+     * Returns the parsed YAML of the currently-active hardware doc on the system,
+     * captured by the parent right before the workflow starts so the diff is
+     * computed against the state Gazebo originally loaded — not the post-activate state.
+     */
+    getPreRunActiveSnapshot: () => Record<string, unknown> | null;
 }
 
 export function useActivateConfigureWorkflow({
@@ -109,12 +120,19 @@ export function useActivateConfigureWorkflow({
     isConnected,
     robotPackageName,
     refetchActiveHardware,
+    getPreRunActiveSnapshot,
 }: UseActivateConfigureWorkflowParams) {
     const [workflowRunning, setWorkflowRunning] = useState(false);
     const [steps, setSteps] = useState<WorkflowStepSlice[]>(() => initialSteps(false, false, false));
     const [detailLine, setDetailLine] = useState('');
+    const [lastRunSucceeded, setLastRunSucceeded] = useState(false);
+    const [lastRunDiff, setLastRunDiff] = useState<HardwareConfigDiff | null>(null);
     const abortRef = useRef<(() => void) | null>(null);
     const runIdRef = useRef(0);
+    /** Snapshot of pre-run active doc, captured at the start of each run. */
+    const preRunActiveDocRef = useRef<Record<string, unknown> | null>(null);
+    /** Parsed YAML of the target preset (loaded once per run). */
+    const targetDocRef = useRef<Record<string, unknown> | null>(null);
 
     const workflowOverallPercent = computeWorkflowOverallPercent(steps);
 
@@ -127,9 +145,23 @@ export function useActivateConfigureWorkflow({
         (simulationOnly: boolean, buildOnly: boolean, activateOnly: boolean) => {
             setSteps(initialSteps(simulationOnly, buildOnly, activateOnly));
             setDetailLine('');
+            setLastRunSucceeded(false);
+            setLastRunDiff(null);
+            preRunActiveDocRef.current = null;
+            targetDocRef.current = null;
         },
         [],
     );
+
+    const computeAndStoreDiff = useCallback(() => {
+        const before = preRunActiveDocRef.current;
+        const after = targetDocRef.current;
+        if (!before || !after) {
+            setLastRunDiff(null);
+            return;
+        }
+        setLastRunDiff(computeHardwareConfigDiff(before, after));
+    }, []);
 
     const patchStep = useCallback((id: WorkflowStepId, patch: Partial<Omit<WorkflowStepSlice, 'id' | 'title'>>) => {
         setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)));
@@ -168,8 +200,24 @@ export function useActivateConfigureWorkflow({
             const runId = ++runIdRef.current;
             abortRef.current = null;
             setWorkflowRunning(true);
+            setLastRunSucceeded(false);
+            setLastRunDiff(null);
             setSteps(initialSteps(simulationOnly, buildOnly, activateOnly));
             setDetailLine('');
+
+            // Snapshot the active doc the running system loaded so we can later
+            // diff it against the target preset. Failing to capture either side
+            // just means we won't surface a Gazebo-restart prompt.
+            preRunActiveDocRef.current = getPreRunActiveSnapshot();
+            targetDocRef.current = null;
+            try {
+                const targetRes = await HardwareConfigHandler.getConfig(targetConfigName.trim());
+                if (targetRes.success) {
+                    targetDocRef.current = parseHardwareConfigYaml(targetRes.config_yaml || '');
+                }
+            } catch {
+                targetDocRef.current = null;
+            }
 
             const shouldContinue = () => runId === runIdRef.current;
 
@@ -254,6 +302,8 @@ export function useActivateConfigureWorkflow({
                     setDetailLine('Activated — build, flash, and reload skipped.');
                     await refetchActiveHardware();
                     messageApi.success('Configuration activated (build, flash, and reload skipped).');
+                    computeAndStoreDiff();
+                    setLastRunSucceeded(true);
                     return;
                 }
 
@@ -360,6 +410,8 @@ export function useActivateConfigureWorkflow({
                 setDetailLine(wetRes.message || 'Complete');
                 await refetchActiveHardware();
                 messageApi.success(`Workflow finished: ${wetRes.message || 'OK'}`);
+                computeAndStoreDiff();
+                setLastRunSucceeded(true);
             } catch (e) {
                 if (!shouldContinue()) return;
                 const msg = e instanceof Error ? e.message : 'Workflow failed';
@@ -375,7 +427,15 @@ export function useActivateConfigureWorkflow({
                 if (runId === runIdRef.current) setWorkflowRunning(false);
             }
         },
-        [isConnected, messageApi, patchStep, refetchActiveHardware, robotPackageName],
+        [
+            isConnected,
+            messageApi,
+            patchStep,
+            refetchActiveHardware,
+            robotPackageName,
+            getPreRunActiveSnapshot,
+            computeAndStoreDiff,
+        ],
     );
 
     return {
@@ -383,6 +443,8 @@ export function useActivateConfigureWorkflow({
         workflowSteps: steps,
         workflowOverallPercent,
         workflowDetailLine: detailLine,
+        workflowLastRunSucceeded: lastRunSucceeded,
+        workflowLastRunDiff: lastRunDiff,
         runActivateWorkflow,
         abortWorkflow,
         resetWorkflowPresentation,

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigEditor.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigEditor.tsx
@@ -58,7 +58,7 @@ export function useHardwareConfigEditor(params: HardwareConfigEditorParams) {
     const { serverErrorRows, boardColumns, actuatorColumns, pressureSensorColumns } = useHardwareConfigEditorColumns({
         yamlDoc: yaml.yamlDoc,
         serverFieldErrors: yaml.serverFieldErrors,
-        yamlJointCatalog: table.yamlJointCatalog,
+        assignableUrdfJoints: table.assignableUrdfJoints,
         patchDoc: yaml.patchDoc,
         actuatorIdOnFocusRef: yaml.actuatorIdOnFocusRef,
         deleteActuatorAt: mutations.deleteActuatorAt,

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigEditorColumns.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigEditorColumns.tsx
@@ -13,7 +13,7 @@ import { buildPressureSensorColumns } from '../tables/pressureSensorColumns.tsx'
 export interface HardwareConfigEditorColumnsParams {
     yamlDoc: Record<string, unknown> | null;
     serverFieldErrors: Map<string, string[]>;
-    yamlJointCatalog: string[];
+    assignableUrdfJoints: string[];
     patchDoc: (next: Record<string, unknown>) => void;
     actuatorIdOnFocusRef: RefObject<Record<number, string>>;
     deleteActuatorAt: (index: number) => void;
@@ -23,7 +23,7 @@ export interface HardwareConfigEditorColumnsParams {
 export function useHardwareConfigEditorColumns({
     yamlDoc,
     serverFieldErrors,
-    yamlJointCatalog,
+    assignableUrdfJoints,
     patchDoc,
     actuatorIdOnFocusRef,
     deleteActuatorAt,
@@ -49,12 +49,20 @@ export function useHardwareConfigEditorColumns({
                 yamlDoc,
                 serverFieldErrors,
                 outlineBorders,
-                yamlJointCatalog,
+                assignableUrdfJoints,
                 patchDoc,
                 actuatorIdOnFocusRef,
                 deleteActuatorAt,
             }),
-        [yamlDoc, serverFieldErrors, outlineBorders, yamlJointCatalog, patchDoc, actuatorIdOnFocusRef, deleteActuatorAt],
+        [
+            yamlDoc,
+            serverFieldErrors,
+            outlineBorders,
+            assignableUrdfJoints,
+            patchDoc,
+            actuatorIdOnFocusRef,
+            deleteActuatorAt,
+        ],
     );
 
     const pressureSensorColumns = useMemo(

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigTableModel.ts
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigTableModel.ts
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
     asMapping,
+    assignableUrdfJointsFromYaml,
     boardSlots,
-    catalogUrdfJointsFromYaml,
     freePhysicalPinsOnBoard,
     sortedBoardIds,
 } from '../model/documentHelpers.ts';
@@ -97,7 +97,10 @@ export function useHardwareConfigTableModel(yamlDoc: Record<string, unknown> | n
         return typeof v === 'string' ? v.trim() : '';
     }, [yamlDoc]);
 
-    const yamlJointCatalog = useMemo(() => (yamlDoc ? catalogUrdfJointsFromYaml(yamlDoc) : []), [yamlDoc]);
+    const assignableUrdfJoints = useMemo(
+        () => (yamlDoc ? assignableUrdfJointsFromYaml(yamlDoc) : []),
+        [yamlDoc],
+    );
 
     return {
         boardsEligibleForNewActuator,
@@ -106,7 +109,7 @@ export function useHardwareConfigTableModel(yamlDoc: Record<string, unknown> | n
         actuatorRows,
         pressureSensorRows,
         hardwareRobotName,
-        yamlJointCatalog,
+        assignableUrdfJoints,
         addActuatorBoard,
         setAddActuatorBoard,
         addPressureSensorActuatorId,

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
@@ -1,6 +1,7 @@
 import { message } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useActiveHardwareRos } from '../../../contexts/ActiveHardwareRosContext.tsx';
+import { useGazeboRunning } from '../../../hooks/useGazeboRunning.hook.ts';
 import { useRosConnection } from '../../../hooks/useRosConnection.hook.ts';
 import { boardsToFlashGoal } from '../utils/boardsToFlashGoal.ts';
 import { useActivateConfigureWorkflow } from './useActivateConfigureWorkflow.tsx';
@@ -66,6 +67,18 @@ export function useHardwareConfiguration() {
         refetchActiveHardware,
     });
 
+    const gazeboRunning = useGazeboRunning();
+    // Always carry the latest active doc in a ref so the workflow can snapshot
+    // it without re-rendering or stale closures.
+    const activeHardwareDocRef = useRef<Record<string, unknown> | null>(null);
+    useEffect(() => {
+        activeHardwareDocRef.current = activeHardwareDoc;
+    }, [activeHardwareDoc]);
+    const getPreRunActiveSnapshot = useCallback(() => {
+        const doc = activeHardwareDocRef.current;
+        return doc ? (structuredClone(doc) as Record<string, unknown>) : null;
+    }, []);
+
     const pipelineBoardIds = useMemo(
         () => editor.boardRows.map((r) => r.boardId),
         [editor.boardRows],
@@ -81,6 +94,8 @@ export function useHardwareConfiguration() {
         workflowSteps,
         workflowOverallPercent,
         workflowDetailLine,
+        workflowLastRunSucceeded,
+        workflowLastRunDiff,
         runActivateWorkflow,
         abortWorkflow,
         resetWorkflowPresentation,
@@ -89,6 +104,7 @@ export function useHardwareConfiguration() {
         isConnected,
         robotPackageName: serverRobotPackage,
         refetchActiveHardware,
+        getPreRunActiveSnapshot,
     });
 
     useEffect(() => {
@@ -209,6 +225,9 @@ export function useHardwareConfiguration() {
         workflowSteps,
         workflowOverallPercent,
         workflowDetailLine,
+        workflowLastRunSucceeded,
+        workflowLastRunDiff,
+        gazeboRunning,
         modalCanRun,
         pipelineBoardOptions,
         editorLocked,

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
@@ -26,15 +26,31 @@ export function useHardwareConfiguration() {
     const [activateModalBoards, setActivateModalBoards] = useState<string[]>([]);
     const [activateModalBuildOnly, setActivateModalBuildOnlyInner] = useState(false);
     const [activateModalActivateOnly, setActivateModalActivateOnlyInner] = useState(false);
+    const [activateModalSimulationOnly, setActivateModalSimulationOnlyInner] = useState(false);
 
     const setActivateModalBuildOnly = useCallback((v: boolean) => {
         setActivateModalBuildOnlyInner(v);
-        if (v) setActivateModalActivateOnlyInner(false);
+        if (v) {
+            setActivateModalActivateOnlyInner(false);
+            setActivateModalSimulationOnlyInner(false);
+        }
     }, []);
 
     const setActivateModalActivateOnly = useCallback((v: boolean) => {
         setActivateModalActivateOnlyInner(v);
-        if (v) setActivateModalBuildOnlyInner(false);
+        if (v) {
+            setActivateModalBuildOnlyInner(false);
+            setActivateModalSimulationOnlyInner(false);
+        }
+    }, []);
+
+    const setActivateModalSimulationOnly = useCallback((v: boolean) => {
+        setActivateModalSimulationOnlyInner(v);
+        if (v) {
+            setActivateModalBuildOnlyInner(false);
+            setActivateModalActivateOnlyInner(false);
+            setActivateModalBoards([]);
+        }
     }, []);
 
     const lists = useHardwareConfigLists(isConnected, messageApi);
@@ -77,32 +93,44 @@ export function useHardwareConfiguration() {
 
     useEffect(() => {
         if (!activateModalOpen) return;
-        resetWorkflowPresentation(activateModalBuildOnly, activateModalActivateOnly);
+        resetWorkflowPresentation(
+            activateModalSimulationOnly,
+            activateModalBuildOnly,
+            activateModalActivateOnly,
+        );
     }, [
         activateModalOpen,
+        activateModalSimulationOnly,
         activateModalBuildOnly,
         activateModalActivateOnly,
         resetWorkflowPresentation,
     ]);
 
-    /** Empty board checkbox selection must not mean “flash everything” — force ACTIVATE ONLY. */
     useEffect(() => {
         if (!activateModalOpen || workflowRunning) return;
-        if (pipelineBoardIds.length === 0 || activateModalBoards.length > 0) return;
-        setActivateModalActivateOnly(true);
+        if (pipelineBoardIds.length === 0) {
+            setActivateModalSimulationOnlyInner(true);
+            return;
+        }
+        if (activateModalBoards.length === 0 && !activateModalSimulationOnly) {
+            setActivateModalActivateOnlyInner(true);
+        }
     }, [
         activateModalOpen,
         workflowRunning,
         pipelineBoardIds.length,
         activateModalBoards.length,
+        activateModalSimulationOnly,
         setActivateModalActivateOnly,
     ]);
 
     const openActivateModal = useCallback(() => {
-        setActivateModalBoards([...pipelineBoardIds]);
+        const simDefault = pipelineBoardIds.length === 0;
+        setActivateModalSimulationOnlyInner(simDefault);
+        setActivateModalBoards(simDefault ? [] : [...pipelineBoardIds]);
         setActivateModalBuildOnlyInner(false);
         setActivateModalActivateOnlyInner(false);
-        resetWorkflowPresentation(false, false);
+        resetWorkflowPresentation(simDefault, false, false);
         setActivateModalOpen(true);
     }, [pipelineBoardIds, resetWorkflowPresentation]);
 
@@ -111,22 +139,37 @@ export function useHardwareConfiguration() {
         setActivateModalOpen(false);
     }, [workflowRunning]);
 
+    const onActivateModalBoardsChange = useCallback(
+        (ids: string[]) => {
+            setActivateModalBoards(ids);
+            if (ids.length === 0) {
+                setActivateModalSimulationOnlyInner(true);
+            } else {
+                setActivateModalSimulationOnlyInner(false);
+            }
+        },
+        [],
+    );
+
     const runWorkflowFromModal = useCallback(async () => {
         const name = editor.loadConfigName.trim();
         if (!name) return;
-        const flashBoards = boardsToFlashGoal(activateModalBoards, pipelineBoardIds);
-        const noBoardsSelected = pipelineBoardIds.length > 0 && activateModalBoards.length === 0;
+        const simulationOnly = activateModalSimulationOnly || pipelineBoardIds.length === 0;
+        const flashBoards = simulationOnly ? [] : boardsToFlashGoal(activateModalBoards, pipelineBoardIds);
+        const noBoardsSelected = !simulationOnly && pipelineBoardIds.length > 0 && activateModalBoards.length === 0;
         await runActivateWorkflow({
             targetConfigName: name,
             boardsToFlash: flashBoards,
             buildOnly: activateModalBuildOnly,
             activateOnly: activateModalActivateOnly || noBoardsSelected,
+            simulationOnly,
             refreshSavedConfigs: editor.refreshConfigListForModal,
         });
     }, [
         activateModalBoards,
         activateModalActivateOnly,
         activateModalBuildOnly,
+        activateModalSimulationOnly,
         editor.loadConfigName,
         editor.refreshConfigListForModal,
         pipelineBoardIds,
@@ -136,7 +179,8 @@ export function useHardwareConfiguration() {
     const modalCanRun =
         Boolean(editor.selectedTargetConfigName.trim()) &&
         Boolean(serverRobotPackage.trim()) &&
-        (pipelineBoardIds.length === 0 ||
+        (activateModalSimulationOnly ||
+            pipelineBoardIds.length === 0 ||
             activateModalBoards.length > 0 ||
             activateModalActivateOnly);
 
@@ -150,11 +194,13 @@ export function useHardwareConfiguration() {
         serverRobotPackage,
         activateModalOpen,
         activateModalBoards,
-        setActivateModalBoards,
+        setActivateModalBoards: onActivateModalBoardsChange,
         activateModalBuildOnly,
         setActivateModalBuildOnly,
         activateModalActivateOnly,
         setActivateModalActivateOnly,
+        activateModalSimulationOnly,
+        setActivateModalSimulationOnly,
         openActivateModal,
         closeActivateModal,
         runWorkflowFromModal,

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
@@ -45,15 +45,6 @@ export function useHardwareConfiguration() {
         }
     }, []);
 
-    const setActivateModalSimulationOnly = useCallback((v: boolean) => {
-        setActivateModalSimulationOnlyInner(v);
-        if (v) {
-            setActivateModalBuildOnlyInner(false);
-            setActivateModalActivateOnlyInner(false);
-            setActivateModalBoards([]);
-        }
-    }, []);
-
     const lists = useHardwareConfigLists(isConnected, messageApi);
     const editor = useHardwareConfigEditor({
         messageApi,
@@ -86,6 +77,24 @@ export function useHardwareConfiguration() {
 
     const pipelineBoardOptions = useMemo(
         () => pipelineBoardIds.map((id) => ({ label: id, value: id })),
+        [pipelineBoardIds],
+    );
+
+    const setActivateModalSimulationOnly = useCallback(
+        (v: boolean) => {
+            setActivateModalSimulationOnlyInner(v);
+            if (v) {
+                setActivateModalBuildOnlyInner(false);
+                setActivateModalActivateOnlyInner(false);
+                setActivateModalBoards([]);
+            } else {
+                // Leaving SIMULATION ONLY pre-selects all known boards so the
+                // hardware workflow is immediately runnable.
+                setActivateModalBoards((prev) =>
+                    prev.length === 0 && pipelineBoardIds.length > 0 ? [...pipelineBoardIds] : prev,
+                );
+            }
+        },
         [pipelineBoardIds],
     );
 
@@ -141,14 +150,15 @@ export function useHardwareConfiguration() {
     ]);
 
     const openActivateModal = useCallback(() => {
-        const simDefault = pipelineBoardIds.length === 0;
-        setActivateModalSimulationOnlyInner(simDefault);
-        setActivateModalBoards(simDefault ? [] : [...pipelineBoardIds]);
+        // Default to SIMULATION ONLY so the modal opens with the safe sim flow;
+        // users with real boards can disable the switch (which pre-selects all boards).
+        setActivateModalSimulationOnlyInner(true);
+        setActivateModalBoards([]);
         setActivateModalBuildOnlyInner(false);
         setActivateModalActivateOnlyInner(false);
-        resetWorkflowPresentation(simDefault, false, false);
+        resetWorkflowPresentation(true, false, false);
         setActivateModalOpen(true);
-    }, [pipelineBoardIds, resetWorkflowPresentation]);
+    }, [resetWorkflowPresentation]);
 
     const closeActivateModal = useCallback(() => {
         if (workflowRunning) return;

--- a/src/features/hardwareConfiguration/model/documentHelpers.ts
+++ b/src/features/hardwareConfiguration/model/documentHelpers.ts
@@ -1,4 +1,5 @@
 import type { CellErrorOpts } from '../../../Utils/hardwareConfigServerErrors.ts';
+import { listIgnoreUrdfJoints, listPassiveUrdfJoints } from './passiveUrdf.ts';
 
 export function asMapping(v: unknown): Record<string, unknown> | null {
     return v !== null && typeof v === 'object' && !Array.isArray(v)
@@ -49,30 +50,39 @@ export function usedUrdfJointsOnOtherRows(actuators: Record<string, unknown>[], 
     return s;
 }
 
+/**
+ * Build the JOINT select options for one actuator row.
+ *
+ * `catalog` is the pool of joint names assignable to actuators (typically
+ * `assignableUrdfJointsFromYaml(doc)` — passive joints minus ignore minus already-assigned).
+ * `usedElsewhere` is the set of joints assigned on *other* actuator rows (defensive filter:
+ * a stale entry leaking into `catalog` is still hidden).
+ * `currentJoint` is the joint name on the row being edited; it is always kept in the list so
+ * legacy rows whose joint is no longer in the pool remain visible (and re-selectable).
+ *
+ * Options are always selectable — the previous "disable" behaviour produced a fully greyed-out
+ * dropdown for any new actuator row (every option was on some other row, current was empty).
+ */
 export function jointSelectOptions(
     catalog: string[],
     usedElsewhere: Set<string>,
     currentJoint: string,
-): { value: string; label: string; disabled: boolean }[] {
+): { value: string; label: string }[] {
     const cur = currentJoint.trim();
-    const catSorted = [...catalog].sort();
     const ordered: string[] = [];
     const seen = new Set<string>();
-    if (cur && !catalog.includes(cur)) {
+    if (cur) {
         ordered.push(cur);
         seen.add(cur);
     }
+    const catSorted = [...catalog].sort();
     for (const j of catSorted) {
-        if (!seen.has(j)) {
-            ordered.push(j);
-            seen.add(j);
-        }
+        if (seen.has(j)) continue;
+        if (usedElsewhere.has(j)) continue;
+        ordered.push(j);
+        seen.add(j);
     }
-    return ordered.map((j) => ({
-        value: j,
-        label: j,
-        disabled: Boolean(j !== cur && usedElsewhere.has(j)),
-    }));
+    return ordered.map((j) => ({ value: j, label: j }));
 }
 
 /** Physical pins already claimed on `boardId`, optionally ignoring one actuator or sensor row (YAML array index). */
@@ -250,21 +260,32 @@ export function defaultNewPressureSensorRow(
     };
 }
 
-/** URDF joints allowed for actuators: optional root `candidate_urdf_joints` ∪ each actuator's `urdf_joint`. */
-export function catalogUrdfJointsFromYaml(doc: Record<string, unknown>): string[] {
-    const names = new Set<string>();
+/**
+ * URDF joints currently free to assign to an actuator row.
+ *
+ * Pool source: `passive_urdf_joints` (and synonyms `urdf_passive`, `urdf_passive_joints`) —
+ * the canonical "unassigned URDF joints" list maintained by the editor itself
+ * (see `passiveUrdf.ts::appendPassiveUrdfJointIfUnassigned`, fired on delete / clear).
+ *
+ * Filters:
+ *   - Drop anything in `ignore_urdf_joints` (and synonyms): those are URDF joints the operator
+ *     never wants exposed as actuator candidates (fixed fingers, helper links, …).
+ *   - Drop joints already mapped to any actuator row — they're "taken", not assignable.
+ *
+ * Note: per-row exclusions (everything assigned on *other* rows while keeping the row's own
+ * value visible) are still applied in `jointSelectOptions` for safety.
+ */
+export function assignableUrdfJointsFromYaml(doc: Record<string, unknown>): string[] {
+    const ignore = new Set<string>(listIgnoreUrdfJoints(doc));
+    const assigned = new Set<string>();
     if (Array.isArray(doc.actuators)) {
         for (const a of doc.actuators) {
             const m = asMapping(a);
             const j = String(m?.urdf_joint ?? '').trim();
-            if (j) names.add(j);
+            if (j) assigned.add(j);
         }
     }
-    const extra = doc.candidate_urdf_joints;
-    if (Array.isArray(extra)) {
-        for (const x of extra) {
-            if (typeof x === 'string' && x.trim()) names.add(x.trim());
-        }
-    }
-    return [...names].sort();
+
+    const pool = new Set<string>(listPassiveUrdfJoints(doc));
+    return [...pool].filter((j) => !ignore.has(j) && !assigned.has(j)).sort();
 }

--- a/src/features/hardwareConfiguration/model/hardwareConfigDiff.ts
+++ b/src/features/hardwareConfiguration/model/hardwareConfigDiff.ts
@@ -1,0 +1,172 @@
+/**
+ * Structural diff between two hardware YAML documents (system "active" vs editor "target").
+ *
+ * Used to predict whether applying the target requires a Gazebo restart. The pipeline
+ * regenerates `inmoov_ros2_control.xacro`; any change there that the running
+ * `gz_ros2_control` plugin reads at robot spawn requires a Gazebo restart (the
+ * plugin only loads URDF + ros2_control blocks once per spawn).
+ *
+ * Server-side ros2_control template fields ⇒ included in the diff:
+ *   - board (per actuator)
+ *   - urdf_joint (per actuator)
+ *   - virtual_pin, servo_type, offset_deg, direction, scale,
+ *     servo_min_deg, servo_max_deg, servo_default_deg (per actuator)
+ *
+ * NOT included (firmware-only or runtime-only):
+ *   - actuator.enabled (firmware emits, but ros2_control still exports the joint)
+ *   - sensors (firmware only)
+ *   - passive_urdf_joints / ignore_urdf_joints (controllers.yaml only,
+ *     applied by RELOAD without Gazebo restart)
+ */
+
+import { asMapping } from './documentHelpers.ts';
+
+/** Fields of an actuator that are baked into the generated ros2_control xacro. */
+const ROS2_CONTROL_ACTUATOR_FIELDS = [
+    'board',
+    'urdf_joint',
+    'virtual_pin',
+    'servo_type',
+    'offset_deg',
+    'direction',
+    'scale',
+    'servo_min_deg',
+    'servo_max_deg',
+    'servo_default_deg',
+] as const;
+
+type Actuator = Record<string, unknown>;
+
+export interface ActuatorFieldChange {
+    field: (typeof ROS2_CONTROL_ACTUATOR_FIELDS)[number];
+    before: unknown;
+    after: unknown;
+}
+
+export interface ActuatorDiffEntry {
+    actuatorId: string;
+    /** Stable label for the UI — falls back to actuator id. */
+    label: string;
+    changes: ActuatorFieldChange[];
+}
+
+export interface HardwareConfigDiff {
+    /** Actuators present in target but missing from active (new in target). */
+    actuatorsAdded: { actuatorId: string; label: string }[];
+    /** Actuators present in active but removed from target. */
+    actuatorsRemoved: { actuatorId: string; label: string }[];
+    /** Actuators in both, but with at least one ros2_control field changed. */
+    actuatorsModified: ActuatorDiffEntry[];
+    /** Boards added in target. */
+    boardsAdded: string[];
+    /** Boards removed in target. */
+    boardsRemoved: string[];
+    /** True if any of the above lists is non-empty. */
+    requiresGazeboRestart: boolean;
+}
+
+function actuatorsFromDoc(doc: Record<string, unknown> | null | undefined): Map<string, Actuator> {
+    const out = new Map<string, Actuator>();
+    if (!doc || !Array.isArray(doc.actuators)) return out;
+    for (const a of doc.actuators) {
+        const m = asMapping(a);
+        if (!m) continue;
+        const id = String(m.id ?? '').trim();
+        if (!id) continue;
+        out.set(id, m);
+    }
+    return out;
+}
+
+function boardIdsFromDoc(doc: Record<string, unknown> | null | undefined): Set<string> {
+    const ids = new Set<string>();
+    const boards = asMapping(doc?.boards);
+    if (!boards) return ids;
+    for (const k of Object.keys(boards)) ids.add(k);
+    return ids;
+}
+
+function actuatorLabel(a: Actuator, fallbackId: string): string {
+    const urdf = String(a.urdf_joint ?? '').trim();
+    return urdf ? `${fallbackId} (${urdf})` : fallbackId;
+}
+
+function valuesDiffer(before: unknown, after: unknown): boolean {
+    // Treat missing/undefined and empty-string-only differences as equal where servo configs
+    // typically default; but for the comparison we err on "different" if either is set.
+    if (before === after) return false;
+    const bs = before === undefined || before === null ? '' : String(before);
+    const as_ = after === undefined || after === null ? '' : String(after);
+    return bs !== as_;
+}
+
+/**
+ * Compute the structural diff used to decide if Gazebo restart is required.
+ *
+ * Accepts null on either side: if `activeDoc` is null we cannot decide, and we
+ * return `requiresGazeboRestart=false` with empty lists — callers should not
+ * prompt the user in that case.
+ */
+export function computeHardwareConfigDiff(
+    activeDoc: Record<string, unknown> | null | undefined,
+    targetDoc: Record<string, unknown> | null | undefined,
+): HardwareConfigDiff {
+    const active = actuatorsFromDoc(activeDoc);
+    const target = actuatorsFromDoc(targetDoc);
+
+    const activeBoards = boardIdsFromDoc(activeDoc);
+    const targetBoards = boardIdsFromDoc(targetDoc);
+
+    const actuatorsAdded: { actuatorId: string; label: string }[] = [];
+    const actuatorsRemoved: { actuatorId: string; label: string }[] = [];
+    const actuatorsModified: ActuatorDiffEntry[] = [];
+
+    for (const [id, ta] of target) {
+        if (!active.has(id)) {
+            actuatorsAdded.push({ actuatorId: id, label: actuatorLabel(ta, id) });
+        }
+    }
+    for (const [id, aa] of active) {
+        if (!target.has(id)) {
+            actuatorsRemoved.push({ actuatorId: id, label: actuatorLabel(aa, id) });
+        }
+    }
+    for (const [id, ta] of target) {
+        const aa = active.get(id);
+        if (!aa) continue;
+        const changes: ActuatorFieldChange[] = [];
+        for (const field of ROS2_CONTROL_ACTUATOR_FIELDS) {
+            if (valuesDiffer(aa[field], ta[field])) {
+                changes.push({ field, before: aa[field], after: ta[field] });
+            }
+        }
+        if (changes.length > 0) {
+            actuatorsModified.push({ actuatorId: id, label: actuatorLabel(ta, id), changes });
+        }
+    }
+
+    const boardsAdded: string[] = [];
+    const boardsRemoved: string[] = [];
+    for (const id of targetBoards) if (!activeBoards.has(id)) boardsAdded.push(id);
+    for (const id of activeBoards) if (!targetBoards.has(id)) boardsRemoved.push(id);
+
+    const requiresGazeboRestart =
+        actuatorsAdded.length > 0 ||
+        actuatorsRemoved.length > 0 ||
+        actuatorsModified.length > 0 ||
+        boardsAdded.length > 0 ||
+        boardsRemoved.length > 0;
+
+    return {
+        actuatorsAdded,
+        actuatorsRemoved,
+        actuatorsModified,
+        boardsAdded,
+        boardsRemoved,
+        requiresGazeboRestart,
+    };
+}
+
+export function isDiffEmpty(diff: HardwareConfigDiff): boolean {
+    return !diff.requiresGazeboRestart;
+}

--- a/src/features/hardwareConfiguration/model/passiveUrdf.ts
+++ b/src/features/hardwareConfiguration/model/passiveUrdf.ts
@@ -15,6 +15,45 @@ export function jointListedUnderKeys(doc: Record<string, unknown>, keys: readonl
     return false;
 }
 
+/** Return the merged, trimmed, deduped, sorted union of joint names listed under any of `keys`. */
+export function collectJointsUnderKeys(doc: Record<string, unknown>, keys: readonly string[]): string[] {
+    const bag = new Set<string>();
+    for (const key of keys) {
+        const arr = doc[key];
+        if (!Array.isArray(arr)) continue;
+        for (const x of arr) {
+            if (typeof x === 'string' && x.trim()) bag.add(x.trim());
+        }
+    }
+    return [...bag].sort();
+}
+
+/** Convenience: union of `passive_urdf_joints` and its synonyms. */
+export function listPassiveUrdfJoints(doc: Record<string, unknown>): string[] {
+    return collectJointsUnderKeys(doc, URDF_PASSIVE_LIST_KEYS);
+}
+
+/** Convenience: union of `ignore_urdf_joints` and its synonyms. */
+export function listIgnoreUrdfJoints(doc: Record<string, unknown>): string[] {
+    return collectJointsUnderKeys(doc, URDF_IGNORE_LIST_KEYS);
+}
+
+/**
+ * Remove `jointName` from every `passive_urdf_joints` synonym key in-place.
+ * After-call invariant: no passive synonym key contains `jointName`. Empty arrays are kept
+ * (we never delete the key) to preserve user-authored schema shape.
+ */
+export function removePassiveUrdfJoint(doc: Record<string, unknown>, jointName: string): void {
+    const j = jointName.trim();
+    if (!j) return;
+    for (const key of URDF_PASSIVE_LIST_KEYS) {
+        const arr = doc[key];
+        if (!Array.isArray(arr)) continue;
+        const next = arr.filter((x) => !(typeof x === 'string' && x.trim() === j));
+        if (next.length !== arr.length) doc[key] = next;
+    }
+}
+
 /** After removing an actuator: record its URDF joint under `passive_urdf_joints` if nothing else maps it. */
 export function appendPassiveUrdfJointIfUnassigned(doc: Record<string, unknown>, jointName: string): void {
     const j = jointName.trim();
@@ -25,14 +64,7 @@ export function appendPassiveUrdfJointIfUnassigned(doc: Record<string, unknown>,
         if (String(m?.urdf_joint ?? '').trim() === j) return;
     }
     if (jointListedUnderKeys(doc, URDF_IGNORE_LIST_KEYS, j)) return;
-    const bag = new Set<string>();
-    for (const key of URDF_PASSIVE_LIST_KEYS) {
-        const passive = doc[key];
-        if (!Array.isArray(passive)) continue;
-        for (const x of passive) {
-            if (typeof x === 'string' && x.trim()) bag.add(x.trim());
-        }
-    }
+    const bag = new Set<string>(listPassiveUrdfJoints(doc));
     if (bag.has(j)) return;
     bag.add(j);
     doc.passive_urdf_joints = [...bag].sort();

--- a/src/features/hardwareConfiguration/tables/actuatorColumns.tsx
+++ b/src/features/hardwareConfiguration/tables/actuatorColumns.tsx
@@ -18,12 +18,16 @@ import {
     usedPhysicalPinsOnBoardExcluding,
     usedUrdfJointsOnOtherRows,
 } from '../model/documentHelpers.ts';
+import {
+    appendPassiveUrdfJointIfUnassigned,
+    removePassiveUrdfJoint,
+} from '../model/passiveUrdf.ts';
 
 export type ActuatorColumnsArgs = {
     yamlDoc: Record<string, unknown> | null;
     serverFieldErrors: Map<string, string[]>;
     outlineBorders: OutlineBorderSet;
-    yamlJointCatalog: string[];
+    assignableUrdfJoints: string[];
     patchDoc: (next: Record<string, unknown>) => void;
     actuatorIdOnFocusRef: RefObject<Record<number, string>>;
     deleteActuatorAt: (index: number) => void;
@@ -33,7 +37,7 @@ export function buildActuatorColumns({
     yamlDoc,
     serverFieldErrors,
     outlineBorders,
-    yamlJointCatalog,
+    assignableUrdfJoints,
     patchDoc,
     actuatorIdOnFocusRef,
     deleteActuatorAt,
@@ -122,10 +126,14 @@ export function buildActuatorColumns({
                 const { row, index } = record;
                 const id = String(row.id ?? index);
                 const ao = actOpts(id, 'urdf_joint');
-                const cur = String(row.urdf_joint ?? '');
+                const cur = String(row.urdf_joint ?? '').trim();
                 const list = (yamlDoc?.actuators ?? []) as Record<string, unknown>[];
                 const used = usedUrdfJointsOnOtherRows(list, index);
-                const options = jointSelectOptions(yamlJointCatalog, used, cur);
+                const options = jointSelectOptions(assignableUrdfJoints, used, cur);
+                const hasFreePassive = options.some((o) => o.value !== cur);
+                const placeholder = hasFreePassive
+                    ? 'SELECT PASSIVE URDF JOINT'
+                    : 'NO FREE PASSIVE URDF JOINT';
                 return (
                     <div title={cellTooltipText(serverFieldErrors, ao)}>
                         <Select
@@ -137,16 +145,22 @@ export function buildActuatorColumns({
                                 minWidth: 180,
                                 ...cellOutlineStyle(serverFieldErrors, ao, outlineBorders),
                             }}
-                            placeholder={
-                                yamlJointCatalog.length ? 'SELECT JOINT' : 'ADD CANDIDATE_URDF_JOINTS TO YAML'
-                            }
+                            placeholder={placeholder}
                             value={cur || undefined}
                             options={options}
                             onChange={(j) => {
                                 if (!yamlDoc) return;
+                                const nextJoint = typeof j === 'string' ? j.trim() : '';
                                 const next = structuredClone(yamlDoc);
                                 const actuators = next.actuators as Record<string, unknown>[];
-                                actuators[index] = { ...actuators[index], urdf_joint: j };
+                                actuators[index] = { ...actuators[index], urdf_joint: nextJoint };
+                                // Keep passive_urdf_joints consistent with the assignment delta:
+                                //   - chosen joint leaves the passive pool (it's now mapped),
+                                //   - previous joint (if any) re-enters the pool when no row claims it.
+                                if (nextJoint) removePassiveUrdfJoint(next, nextJoint);
+                                if (cur && cur !== nextJoint) {
+                                    appendPassiveUrdfJointIfUnassigned(next, cur);
+                                }
                                 patchDoc(next);
                             }}
                         />

--- a/src/hooks/useGazeboRunning.hook.ts
+++ b/src/hooks/useGazeboRunning.hook.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { GazeboStatusHandler } from '../Services/ros/handlers/GazeboStatus.handler.ts';
+
+/**
+ * Reactive wrapper over `GazeboStatusHandler`.
+ *
+ * Returns the latest `/lucy/gazebo_running` value, or `null` while we have
+ * not received a message yet (use the null state to avoid prompts based on
+ * a stale assumption).
+ */
+export function useGazeboRunning(): boolean | null {
+    const [value, setValue] = useState<boolean | null>(GazeboStatusHandler.getInstance().value);
+    useEffect(() => {
+        const off = GazeboStatusHandler.getInstance().subscribe(setValue);
+        return off;
+    }, []);
+    return value;
+}


### PR DESCRIPTION
## Summary
- Hardware configuration: activate modal gains a SIMULATION ONLY switch (default ON), board selection collapses in sim mode, BUILD/FLASH are marked skipped, and the workflow runs VALIDATE → ACTIVATE → RELOAD against the new pipeline goal field.
- Post-success UX: neutral RUN AGAIN + green DONE buttons, plus a structural diff of the pre-run active doc vs the new target that drives a `GAZEBO RESTART REQUIRED / NOT REQUIRED` banner with two-path Ctrl+C instructions (`./launch_lucy.sh` or `ros2 launch …`). Uses a new `GazeboStatus` handler subscribed to the latched `/lucy/gazebo_running` topic.
- Actuator dropdowns now list joints from `passive_urdf_joints` (filtered instead of disabled) and keep that pool in sync on assign/clear.
- App shell: routes are mounted once and toggled via `display:none` so CONTROL / CONFIGURATION / 3D VIEW retain local state across navigation.
- New branded `LucyLoader` replaces the static "Connect to ROS" alerts and Suspense fallbacks.
- Rosbridge service: connect errors no longer surface `[object Event]`; the alert shows the failure reason and instructs the user to run `ros2 launch lucy_bringup lucy.launch.py gazebo:=true rviz:=true`. Connection timeouts now actually reject the connect promise.
