### PR TITLE
feat(control-panel): add GENERATE step in activate/configure workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ The application features a distinctive green-on-black cyberpunk aesthetic remini
 
 ## 🚀 Features
 
-- **🎮 Real-time Joint Control** - Individual control of all robot joints with precision sliders and input fields
+- **🎮 Real-time Joint Control** - Individual control of all robot joints with precision sliders and input fields. Sliders display the **hardware-defined** servo range (`servo_min_deg` / `servo_max_deg` from the active YAML) so you can probe the full mechanical envelope; URDF `<limit>` enforcement is performed downstream by `ros2_control` (`LucySystemHardware`).
 - **👥 Multi-client exclusive control** - Multiple browsers can connect simultaneously; only one publishes at a time — see [Connection & Control user flow](docs/guides/connection-and-control.md)
-- **📡 Live motor feedback** - Shows the actual joint position in real time
+- **📡 Live motor feedback** - 3D viewer and slider readback consume `/joint_states` (URDF radians) and convert to servo degrees with the per-joint mapping (`offset_deg`, `direction`, `scale`).
 - **🎯 URDF Parser** - Automatic parsing of InMoov URDF files to extract joint configurations and constraints
 - **💾 Pose Management** - Save, load, and manage multiple robot poses with custom names
+- **⚙️ Activate / Configure workflow** - Five-step pipeline (VALIDATE → GENERATE → BUILD → FLASH → RELOAD) with a dedicated **GENERATE** step that regenerates `ros2_control` xacro + `controllers.yaml` even in *SIMULATION ONLY* mode (no firmware build).
 - **🔄 Drag & Drop Categories** - Reorganize joint categories (Head, Arms, Torso, etc.) via intuitive drag-and-drop
 - **📐 Unit Conversion** - Toggle between degrees and radians for joint angle display
 - **🤖 3D Robot Visualization** - Real-time 3D rendering of robot meshes with STL support

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -99,17 +99,48 @@ flowchart TD
 ```mermaid
 sequenceDiagram
     actor User
-    participant Slider as JointControl (slider)
+    participant Slider as JointControl (slider, servo deg)
     participant Panel as RobotControlPanel
     participant JSH as JointStateHandler
     participant WS as RosBridgeService (WebSocket)
-    participant ROS as ros2_control
+    participant ROS as ros2_control / LucySystemHardware
 
-    User->>Slider: moves slider
-    Slider->>Panel: onJointChange(name, value)
+    User->>Slider: moves slider (servo deg)
+    Slider->>Panel: onJointChange(name, servo_deg)
+    Panel->>Panel: servoDegToJointRad(name, servo_deg)
     Panel->>JSH: publishJointStates(joints)
     JSH->>JSH: group joints by controller
     JSH->>WS: topic.publish(JointTrajectory)
     WS->>ROS: trajectory_msgs/JointTrajectory\n[names, positions (rad), t=0.2 s]
-    ROS-->>Hardware: drive servos
+    ROS->>ROS: clamp to URDF <command_interface min/max>
+    ROS-->>Hardware: drive actuators (clamped)
+    ROS-->>JSH: /joint_states (URDF rad, clamped)
+    JSH-->>Slider: jointRadToServoDeg → actualValue
 ```
+
+### Units along the path
+
+| Stage | Unit | Source |
+|-------|------|--------|
+| Slider native | servo degrees | `servo_min_deg` / `servo_max_deg` from the active YAML |
+| Wire to `ros2_control` | URDF radians | `servoDegToJointRad(servo_deg, offset_deg, direction, scale)` |
+| `LucySystemHardware::write()` | URDF radians, clamped | `<command_interface><param name="min/max"/></command_interface>` |
+| `/joint_states` | URDF radians | `joint_state_broadcaster` |
+| 3D viewer + slider readback | servo degrees | `jointRadToServoDeg(joint_rad, offset_deg, direction, scale)` |
+
+The slider exposes the full hardware envelope on purpose — `ros2_control` is the single point that enforces the URDF wall, so the LCP can show the user "your servo can mechanically reach this, but the controller will refuse past *X* deg".
+
+## Activate / Configure workflow
+
+`useActivateConfigureWorkflow.tsx` drives the modal in `ActivateConfigureWorkflowModal.tsx`. The pipeline mirrors the `lucy_config_pipeline` action phases:
+
+| Step | UI | Backend phase | Skipped when |
+|------|----|---------------|--------------|
+| VALIDATE | always shown | `validate` | never |
+| ACTIVATE | always shown | (frontend save + activation) | never |
+| **GENERATE** | always shown | `generate` (regenerates `ros2_control.xacro` + `controllers.yaml`) | never |
+| BUILD | shown when not *SIMULATION ONLY* | `build` | `simulation_only` |
+| FLASH | shown when not *SIMULATION ONLY* | `flash` | `simulation_only`, `build_only` |
+| RELOAD | always shown | `reload` (`/lucy_control/restart`) | never |
+
+The dedicated **GENERATE** step makes it explicit that *SIMULATION ONLY* still rewrites ros2_control configuration; only firmware build/flash are skipped.

--- a/docs/services/ros/handlers/JointState.handler.md
+++ b/docs/services/ros/handlers/JointState.handler.md
@@ -40,7 +40,7 @@ Publishes the current joint positions to `ros2_control`.
 - Iterates over `controllerConfigs`; for each controller, collects only the joints that belong to it (by name).
 - Publishes one `trajectory_msgs/JointTrajectory` per controller with a single waypoint.
 - Uses `time_from_start = 0.2 s` — some controllers reject points with `t = 0`.
-- Positions are in **radians**.
+- Positions are in **URDF radians**. Sliders work in servo degrees; conversion happens at the page layer (`servoDegToJointRad` / `jointRadToServoDeg`) before reaching this handler. URDF clamping is enforced downstream by `LucySystemHardware`, not in the LCP.
 - Silently skips joints not present in the `joints` array.
 
 ```typescript

--- a/src/Components/JointControl.tsx
+++ b/src/Components/JointControl.tsx
@@ -12,7 +12,6 @@ import {
     UI_LIST_ROW_BG,
     UI_TEXT_PRIMARY_ON_DARK,
     UI_TEXT_SECONDARY_MUTED,
-    UI_WARNING,
 } from '../Constants/uiTheme.ts';
 
 const { Text } = Typography;
@@ -53,53 +52,73 @@ export const JointControl: React.FC<JointControlProps> = React.memo(({
     }
   }, [joint.name, joint.minValue, joint.maxValue, onValueChange]);
 
+  const actuatorNative = Boolean(joint.valueInActuatorDegrees && showDegrees);
+
   const displayValues = useMemo(() => {
-    const getDisplayValue = (radians: number): number => {
-      return showDegrees ? Math.round(radianToDegree(radians) * 100) / 100 : Math.round(radians * 1000) / 1000;
+    const getDisplayValue = (value: number): number => {
+      if (actuatorNative) {
+        return Math.round(value * 100) / 100;
+      }
+      return showDegrees
+        ? Math.round(radianToDegree(value) * 100) / 100
+        : Math.round(value * 1000) / 1000;
     };
 
     const getDisplayRange = (): [number, number] => {
+      if (actuatorNative) {
+        return [
+          Math.round(joint.minValue * 100) / 100,
+          Math.round(joint.maxValue * 100) / 100,
+        ];
+      }
       if (showDegrees) {
         return [
           Math.round(radianToDegree(joint.minValue) * 100) / 100,
-          Math.round(radianToDegree(joint.maxValue) * 100) / 100
+          Math.round(radianToDegree(joint.maxValue) * 100) / 100,
         ];
       }
       return [
         Math.round(joint.minValue * 1000) / 1000,
-        Math.round(joint.maxValue * 1000) / 1000
+        Math.round(joint.maxValue * 1000) / 1000,
       ];
     };
 
-        const [minDisplay, maxDisplay] = getDisplayRange();
+    const [minDisplay, maxDisplay] = getDisplayRange();
     const currentDisplay = getDisplayValue(localValue);
 
     return { minDisplay, maxDisplay, currentDisplay };
-  }, [joint.minValue, joint.maxValue, localValue, showDegrees]);
+  }, [joint.minValue, joint.maxValue, localValue, showDegrees, actuatorNative]);
 
   const convertInputValue = useCallback((displayValue: number): number => {
+    if (actuatorNative) {
+      return displayValue;
+    }
     return showDegrees ? degreeToRadian(displayValue) : displayValue;
-  }, [showDegrees]);
+  }, [showDegrees, actuatorNative]);
 
   const { minDisplay, maxDisplay, currentDisplay } = displayValues;
 
   const actualBarPercent = useMemo(() => {
     if (joint.actualValue === undefined) return undefined;
-    const actualDisplay = showDegrees
-      ? Math.round(radianToDegree(joint.actualValue) * 100) / 100
-      : Math.round(joint.actualValue * 1000) / 1000;
+    const actualDisplay = actuatorNative
+      ? Math.round(joint.actualValue * 100) / 100
+      : showDegrees
+        ? Math.round(radianToDegree(joint.actualValue) * 100) / 100
+        : Math.round(joint.actualValue * 1000) / 1000;
     const pct = ((actualDisplay - minDisplay) / (maxDisplay - minDisplay)) * 100;
     return Math.max(0, Math.min(100, pct));
-  }, [joint.actualValue, minDisplay, maxDisplay, showDegrees]);
+  }, [joint.actualValue, minDisplay, maxDisplay, showDegrees, actuatorNative]);
 
   const restBarPercent = useMemo(() => {
     if (joint.restValue === undefined) return undefined;
-    const restDisplay = showDegrees
-      ? Math.round(radianToDegree(joint.restValue) * 100) / 100
-      : Math.round(joint.restValue * 1000) / 1000;
+    const restDisplay = actuatorNative
+      ? Math.round(joint.restValue * 100) / 100
+      : showDegrees
+        ? Math.round(radianToDegree(joint.restValue) * 100) / 100
+        : Math.round(joint.restValue * 1000) / 1000;
     const pct = ((restDisplay - minDisplay) / (maxDisplay - minDisplay)) * 100;
     return Math.max(0, Math.min(100, pct));
-  }, [joint.restValue, minDisplay, maxDisplay, showDegrees]);
+  }, [joint.restValue, minDisplay, maxDisplay, showDegrees, actuatorNative]);
 
   const getJointTypeColor = (type: string): string => {
     switch (type) {
@@ -149,8 +168,8 @@ export const JointControl: React.FC<JointControlProps> = React.memo(({
             />
             {restBarPercent !== undefined && (
               <div
-                title={`Default: ${showDegrees
-                  ? `${Math.round(radianToDegree(joint.restValue!) * 10) / 10}°`
+                title={`Default: ${actuatorNative || showDegrees
+                  ? `${Math.round((actuatorNative ? joint.restValue! : radianToDegree(joint.restValue!)) * 10) / 10}°`
                   : `${Math.round(joint.restValue! * 1000) / 1000}rad`}`}
                 style={{
                   position: 'absolute',
@@ -168,8 +187,8 @@ export const JointControl: React.FC<JointControlProps> = React.memo(({
             )}
             {actualBarPercent !== undefined && (
               <div
-                title={`Actual: ${showDegrees
-                  ? `${Math.round(radianToDegree(joint.actualValue!) * 10) / 10}°`
+                title={`Actual: ${actuatorNative || showDegrees
+                  ? `${Math.round((actuatorNative ? joint.actualValue! : radianToDegree(joint.actualValue!)) * 10) / 10}°`
                   : `${Math.round(joint.actualValue! * 1000) / 1000}rad`}`}
                 style={{
                   position: 'absolute',

--- a/src/Constants/hardwareConfigDefaults.ts
+++ b/src/Constants/hardwareConfigDefaults.ts
@@ -1,0 +1,49 @@
+/**
+ * Default field values for hardware-config editor rows.
+ *
+ * These mirror the expectations of `lucy_config_generator` (servo ranges,
+ * enabled flags, sensor shape). Keep them here so the editor never hardcodes
+ * defaults inline — `documentHelpers.ts` and any future row builder import them.
+ */
+
+/**
+ * Servo type used when an actuator row has a missing/blank `servo_type`
+ * (display normalization fallback — see `normalizeActuatorType`).
+ */
+export const DEFAULT_ACTUATOR_TYPE_FALLBACK = '270';
+
+/** Field defaults applied to a freshly-added actuator row in the editor. */
+export const DEFAULT_NEW_ACTUATOR_VALUES = {
+    servo_type: '180',
+    offset_deg: 0,
+    direction: 1,
+    scale: 1,
+    servo_min_deg: 0,
+    servo_max_deg: 180,
+    servo_default_deg: 90,
+    enabled: false,
+} as const;
+
+/** Field defaults applied to a freshly-added pressure sensor row in the editor. */
+export const DEFAULT_NEW_PRESSURE_SENSOR_VALUES = {
+    type: 'pressure',
+    min_value: null,
+    max_value: null,
+    enabled: true,
+} as const;
+
+/**
+ * Fallback slider bounds (actuator degrees) for a control-panel joint that has
+ * no servo limits in the controller config. Mirrors the 0–180° default servo
+ * travel used elsewhere in the editor.
+ */
+export const DEFAULT_JOINT_SLIDER_BOUNDS_DEG = {
+    min: 0,
+    max: 180,
+} as const;
+
+/**
+ * Fallback slider position (actuator degrees) when a joint exposes no default
+ * (rest) angle — the slider and command both start here.
+ */
+export const DEFAULT_JOINT_SLIDER_VALUE_DEG = 0;

--- a/src/Constants/robotTypes.ts
+++ b/src/Constants/robotTypes.ts
@@ -38,6 +38,12 @@ export interface JointControlState {
   category: string | undefined;
   inverted?: boolean;
   restValue?: number;
+  /**
+   Tells JointControl whether the numeric fields are already actuator
+   * degrees (show verbatim as °, take input as-is) or URDF radians
+   * (convert to ° for display, convert input back)
+   */
+  valueInActuatorDegrees?: boolean;
 }
 
 export interface JointConfiguration {

--- a/src/Constants/rosConfig.ts
+++ b/src/Constants/rosConfig.ts
@@ -1,11 +1,20 @@
-/** Per-joint position limits read from the hardware YAML (servo degrees). */
+/** URDF command ↔ actuator calibration (matches ros2_control hardware params). */
+export interface JointMapping {
+  offsetDeg: number;
+  direction: number;
+  scale: number;
+}
+
+/** Per-joint position limits read from the hardware YAML (actuator degrees). */
 export interface JointLimitDeg {
-  /** Minimum servo angle for this joint (degrees). */
+  /** Minimum actuator angle for this joint (degrees). */
   minDeg: number;
-  /** Maximum servo angle for this joint (degrees). */
+  /** Maximum actuator angle for this joint (degrees). */
   maxDeg: number;
-  /** Default / rest servo angle for this joint (degrees). */
+  /** Default / rest actuator angle for this joint (degrees). */
   defaultDeg: number;
+  /** Calibration used to convert slider (actuator deg) ↔ trajectory (URDF rad). */
+  mapping: JointMapping;
 }
 
 export interface ControllerJointConfig {
@@ -15,7 +24,7 @@ export interface ControllerJointConfig {
   joints: string[];
   /** Default category label for these joints in the panel */
   defaultCategory: string;
-  /** Per-joint servo limits extracted from the hardware YAML. Keyed by URDF joint name. */
+  /** Per-joint actuator limits extracted from the hardware YAML. Keyed by URDF joint name. */
   jointLimits?: Record<string, JointLimitDeg>;
 }
 

--- a/src/Pages/RobotControlPanel.tsx
+++ b/src/Pages/RobotControlPanel.tsx
@@ -43,7 +43,15 @@ import { useActiveHardwareRos } from '../contexts/ActiveHardwareRosContext';
 
 /* Types */
 import type { JointControlState } from '../Constants/robotTypes';
-import { degreeToRadian } from '../Utils/math.utils';
+import {
+    DEFAULT_ACTUATOR_MAPPING,
+    jointRadToActuatorDeg,
+    type ActuatorMapping,
+} from '../Utils/actuatorJointMapping';
+import {
+    DEFAULT_JOINT_SLIDER_BOUNDS_DEG,
+    DEFAULT_JOINT_SLIDER_VALUE_DEG,
+} from '../Constants/hardwareConfigDefaults';
 
 /* Components */
 import { Page } from '../Components/Page';
@@ -86,6 +94,8 @@ export const RobotControlPanel: React.FC = () => {
         refetchActiveHardware,
     } = useActiveHardwareRos();
 
+    const actuatorMappingByJointRef = useRef<Map<string, ActuatorMapping>>(new Map());
+
     const [joints, setJoints] = useState<JointControlState[]>([]);
     const jointsRef = useRef<JointControlState[]>(joints);
     const actualPositionsRef = useRef<Map<string, number>>(new Map());
@@ -121,23 +131,32 @@ export const RobotControlPanel: React.FC = () => {
         })
     );
 
-    /** Build initial joint list from controller config (ros2_control joint names). */
-    const buildJointsFromControllerConfig = useCallback((configs: ControllerJointConfig[]): JointControlState[] => {
-        const defaultMin = 0;
-        const defaultMax = Math.PI;
+    /** Build initial joint list from controller config (slider values in actuator degrees). */
+    const buildJointsFromControllerConfig = useCallback((
+        configs: ControllerJointConfig[],
+    ): JointControlState[] => {
         const joints: JointControlState[] = [];
         for (const c of configs) {
             for (const name of c.joints) {
                 const lim = c.jointLimits?.[name];
+                let minValue = DEFAULT_JOINT_SLIDER_BOUNDS_DEG.min;
+                let maxValue = DEFAULT_JOINT_SLIDER_BOUNDS_DEG.max;
+                let restValue: number | undefined;
+                if (lim) {
+                    minValue = lim.minDeg;
+                    maxValue = lim.maxDeg;
+                    restValue = lim.defaultDeg;
+                }
                 joints.push({
                     name,
-                    currentValue: 0,
-                    targetValue: 0,
-                    minValue: lim ? degreeToRadian(lim.minDeg) : defaultMin,
-                    maxValue: lim ? degreeToRadian(lim.maxDeg) : defaultMax,
+                    currentValue: restValue ?? DEFAULT_JOINT_SLIDER_VALUE_DEG,
+                    targetValue: restValue ?? DEFAULT_JOINT_SLIDER_VALUE_DEG,
+                    minValue,
+                    maxValue,
                     type: 'revolute',
                     category: c.defaultCategory,
-                    ...(lim && { restValue: degreeToRadian(lim.defaultDeg) }),
+                    valueInActuatorDegrees: true,
+                    ...(restValue !== undefined && { restValue }),
                 });
             }
         }
@@ -178,6 +197,14 @@ export const RobotControlPanel: React.FC = () => {
 
         setError(null);
         JointStateHandler.getInstance(ctrls);
+        const mapByJoint = new Map<string, ActuatorMapping>();
+        for (const c of ctrls) {
+            for (const name of c.joints) {
+                const lim = c.jointLimits?.[name];
+                mapByJoint.set(name, lim?.mapping ?? DEFAULT_ACTUATOR_MAPPING);
+            }
+        }
+        actuatorMappingByJointRef.current = mapByJoint;
         setJoints((prev) => {
             const byName = new Map(prev.map((j) => [j.name, j]));
             const next = buildJointsFromControllerConfig(ctrls);
@@ -223,26 +250,34 @@ export const RobotControlPanel: React.FC = () => {
     }, [isConnected]);
 
     // Mirror joint positions published by the controlling client.
-    // joints.length is in deps so we re-subscribe once hardware configs are loaded.
+    // Trajectory payloads are URDF rad — convert to actuator deg for the slider.
     useEffect(() => {
         if (isSending || !isConnected || joints.length === 0) return;
         const unsubscribe = JointStateHandler.getInstance().subscribeToPositions((updates) => {
             setJoints((prev) =>
                 prev.map((j) => {
                     const u = updates.find((x) => x.name === j.name);
-                    return u ? { ...j, currentValue: u.value, targetValue: u.value } : j;
+                    if (!u) return j;
+                    const mapping = actuatorMappingByJointRef.current.get(j.name) ?? DEFAULT_ACTUATOR_MAPPING;
+                    const actuatorDeg = jointRadToActuatorDeg(u.value, mapping);
+                    return { ...j, currentValue: actuatorDeg, targetValue: actuatorDeg };
                 })
             );
         });
         return unsubscribe;
     }, [isSending, isConnected, joints.length]);
 
-    // Subscribe to /joint_states — write into a ref at full ROS rate (no re-renders).
+    // Subscribe to /joint_states (URDF rad) — convert to actuator deg per joint
+    // before storing in the ref so the slider's actualValue is in slider-native units.
     useEffect(() => {
         if (!isConnected || joints.length === 0) return;
         const unsubscribe = JointStateHandler.getInstance().subscribeToJointStates((positions) => {
             for (const { name, value } of positions) {
-                actualPositionsRef.current.set(name, value);
+                const mapping = actuatorMappingByJointRef.current.get(name);
+                actualPositionsRef.current.set(
+                    name,
+                    mapping ? jointRadToActuatorDeg(value, mapping) : value,
+                );
             }
         });
         return () => { unsubscribe(); actualPositionsRef.current.clear(); };

--- a/src/Services/ros/handlers/JointState.handler.ts
+++ b/src/Services/ros/handlers/JointState.handler.ts
@@ -1,6 +1,11 @@
 import ROSLIB from 'roslib';
 import { ROS_CONFIG, type ControllerJointConfig } from '../../../Constants/rosConfig.ts';
 import type { JointControlState } from '../../../Constants/robotTypes.ts';
+import {
+  jointConfigMetaFromControllers,
+  type JointConfigMeta,
+} from '../../../Utils/jointConfigLookup.ts';
+import { actuatorDegToJointRad } from '../../../Utils/actuatorJointMapping.ts';
 import { RosBridgeService } from '../ros.service.ts';
 
 /** ROS time (sec + nsec) for trajectory header; from /clock when use_sim_time, else wall clock. */
@@ -17,9 +22,11 @@ export class JointStateHandler {
   private clockTopic: ROSLIB.Topic | null = null;
   private lastClock: { sec: number; nanosec: number } | null = null;
   private controllerConfigs: ControllerJointConfig[];
+  private jointMetaByName = new Map<string, JointConfigMeta>();
 
   private constructor(controllerConfigs: ControllerJointConfig[]) {
     this.controllerConfigs = controllerConfigs;
+    this.jointMetaByName = jointConfigMetaFromControllers(controllerConfigs);
     this.unsubscribeFromStatus = RosBridgeService.getInstance().onStatusChange((status) => {
       if (status === 'connected') {
         this.initializeTopics();
@@ -70,6 +77,7 @@ export class JointStateHandler {
   /** Update controller config (e.g. after receiving from ROS). */
   setControllerConfigs(controllerConfigs: ControllerJointConfig[]) {
     this.controllerConfigs = controllerConfigs;
+    this.jointMetaByName = jointConfigMetaFromControllers(controllerConfigs);
     this.initializeTopics();
   }
 
@@ -115,8 +123,9 @@ export class JointStateHandler {
 
   /**
    * Subscribe to /joint_states (sensor_msgs/msg/JointState) to get actual motor positions.
-   * Calls `callback` on every message regardless of who is controlling.
-   * Returns a cleanup function.
+   * Values are URDF radians (single source of truth for FK / 3D viewer / RViz).
+   * Slider consumers convert to actuator deg at the call site via
+   * `jointRadToActuatorDeg`. Returns a cleanup function.
    */
   subscribeToJointStates(
     callback: (positions: { name: string; value: number }[]) => void
@@ -140,7 +149,7 @@ export class JointStateHandler {
 
   /**
    * Subscribe to incoming joint trajectory messages (published by another client).
-   * Calls `callback` each time a message arrives on any controller topic.
+   * Values are URDF radians (raw payload). Slider consumers convert at call site.
    * Returns a cleanup function that unsubscribes all listeners.
    */
   subscribeToPositions(
@@ -199,7 +208,11 @@ export class JointStateHandler {
         const j = jointByName.get(name);
         if (j == null) continue;
         names.push(name);
-        positions.push(j.currentValue);
+        const meta = this.jointMetaByName.get(name);
+        const jointRad = meta
+          ? actuatorDegToJointRad(j.currentValue, meta.mapping)
+          : j.currentValue;
+        positions.push(jointRad);
       }
       if (names.length === 0) continue;
       const topic = this.topicByTopicName.get(cfg.topic);

--- a/src/Utils/actuatorJointMapping.ts
+++ b/src/Utils/actuatorJointMapping.ts
@@ -1,0 +1,52 @@
+import { degreeToRadian, radianToDegree } from './math.utils.ts';
+
+/** Per-actuator calibration between actuator degrees and URDF joint commands. */
+export interface ActuatorMapping {
+  offsetDeg: number;
+  direction: number;
+  scale: number;
+}
+
+export const DEFAULT_ACTUATOR_MAPPING: ActuatorMapping = {
+  offsetDeg: 0,
+  direction: 1,
+  scale: 1,
+};
+
+/** joint_rad = deg_to_rad((actuator_deg - offset_deg) * direction * scale) */
+export function actuatorDegToJointRad(actuatorDeg: number, mapping: ActuatorMapping): number {
+  const jointDeg = (actuatorDeg - mapping.offsetDeg) * mapping.direction * mapping.scale;
+  return degreeToRadian(jointDeg);
+}
+
+/** actuator_deg = (rad_to_deg(joint_rad) / (direction * scale)) + offset_deg */
+export function jointRadToActuatorDeg(jointRad: number, mapping: ActuatorMapping): number {
+  const jointDeg = radianToDegree(jointRad);
+  const denom = mapping.direction * mapping.scale;
+  if (denom === 0) {
+    return mapping.offsetDeg;
+  }
+  return jointDeg / denom + mapping.offsetDeg;
+}
+
+export function clampActuatorDeg(value: number, minDeg: number, maxDeg: number): number {
+  return Math.min(Math.max(value, minDeg), maxDeg);
+}
+
+/** Intersect electrical and URDF-mapped actuator envelopes for LCP slider bounds. */
+export function intersectActuatorSliderBounds(
+  actuatorMinDeg: number,
+  actuatorMaxDeg: number,
+  actuatorDefaultDeg: number,
+  urdfLowerRad: number,
+  urdfUpperRad: number,
+  mapping: ActuatorMapping,
+): { minDeg: number; maxDeg: number; defaultDeg: number } {
+  const lo = jointRadToActuatorDeg(urdfLowerRad, mapping);
+  const hi = jointRadToActuatorDeg(urdfUpperRad, mapping);
+  const [mappedLo, mappedHi] = lo <= hi ? [lo, hi] : [hi, lo];
+  const minDeg = Math.max(actuatorMinDeg, mappedLo);
+  const maxDeg = Math.min(actuatorMaxDeg, mappedHi);
+  const defaultDeg = clampActuatorDeg(actuatorDefaultDeg, minDeg, maxDeg);
+  return { minDeg, maxDeg, defaultDeg };
+}

--- a/src/Utils/generatedFiles.ts
+++ b/src/Utils/generatedFiles.ts
@@ -1,0 +1,46 @@
+/**
+ * Generated-artifact filenames, mirroring `generated_files` in the hardware
+ * mapping YAML (see lucy_config_generator/schema.py `resolve_generated_files`).
+ *
+ * The robot stack treats `active.yaml` as the single source of truth for these
+ * names; the LCP only reads them so user-facing copy matches what the pipeline
+ * actually writes. Values are bare filenames — directories are fixed by repo
+ * convention (`description/ros2_control/` and `config/`).
+ */
+export interface GeneratedFileNames {
+    ros2ControlXacro: string;
+    controllersYaml: string;
+}
+
+export const GENERATED_FILE_DEFAULTS: GeneratedFileNames = {
+    ros2ControlXacro: 'inmoov_ros2_control.xacro',
+    controllersYaml: 'controllers.yaml',
+};
+
+function pickBasename(value: unknown, fallback: string): string {
+    if (typeof value !== 'string') return fallback;
+    const trimmed = value.trim();
+    if (!trimmed || trimmed.includes('/') || trimmed.includes('\\')) return fallback;
+    return trimmed;
+}
+
+/**
+ * Resolve the generated filenames from a parsed hardware-config document,
+ * falling back to {@link GENERATED_FILE_DEFAULTS} for any missing/invalid key.
+ */
+export function resolveGeneratedFiles(
+    doc: Record<string, unknown> | null | undefined,
+): GeneratedFileNames {
+    const section =
+        doc && typeof doc === 'object'
+            ? (doc as { generated_files?: unknown }).generated_files
+            : undefined;
+    if (!section || typeof section !== 'object') {
+        return { ...GENERATED_FILE_DEFAULTS };
+    }
+    const s = section as { ros2_control_xacro?: unknown; controllers_yaml?: unknown };
+    return {
+        ros2ControlXacro: pickBasename(s.ros2_control_xacro, GENERATED_FILE_DEFAULTS.ros2ControlXacro),
+        controllersYaml: pickBasename(s.controllers_yaml, GENERATED_FILE_DEFAULTS.controllersYaml),
+    };
+}

--- a/src/Utils/hardwareControllersFromYaml.ts
+++ b/src/Utils/hardwareControllersFromYaml.ts
@@ -1,4 +1,18 @@
-import type { ControllerJointConfig, JointLimitDeg } from '../Constants/rosConfig';
+import type { ControllerJointConfig, JointLimitDeg, JointMapping } from '../Constants/rosConfig';
+import { DEFAULT_ACTUATOR_MAPPING } from './actuatorJointMapping';
+
+function readMapping(row: Record<string, unknown>): JointMapping {
+    const offsetDeg = Number(row.offset_deg);
+    const direction = Number(row.direction);
+    const scale = Number(row.scale);
+    return {
+        offsetDeg: Number.isFinite(offsetDeg) ? offsetDeg : DEFAULT_ACTUATOR_MAPPING.offsetDeg,
+        direction: Number.isFinite(direction) && direction !== 0
+            ? direction
+            : DEFAULT_ACTUATOR_MAPPING.direction,
+        scale: Number.isFinite(scale) && scale !== 0 ? scale : DEFAULT_ACTUATOR_MAPPING.scale,
+    };
+}
 
 function boardIdToCategory(boardId: string): string {
     const tail = boardId.replace(/^rp2040_/, '');
@@ -56,6 +70,7 @@ export function controllerJointConfigsFromHardwareYaml(doc: Record<string, unkno
                     minDeg,
                     maxDeg,
                     defaultDeg: Number.isFinite(defaultDeg) ? defaultDeg : (minDeg + maxDeg) / 2,
+                    mapping: readMapping(r),
                 };
             }
         }

--- a/src/Utils/jointConfigLookup.ts
+++ b/src/Utils/jointConfigLookup.ts
@@ -1,0 +1,24 @@
+import type { ControllerJointConfig, JointLimitDeg } from '../Constants/rosConfig';
+import type { ActuatorMapping } from './actuatorJointMapping';
+import { DEFAULT_ACTUATOR_MAPPING } from './actuatorJointMapping';
+
+export interface JointConfigMeta {
+  limit?: JointLimitDeg;
+  mapping: ActuatorMapping;
+}
+
+export function jointConfigMetaFromControllers(
+  configs: ControllerJointConfig[],
+): Map<string, JointConfigMeta> {
+  const out = new Map<string, JointConfigMeta>();
+  for (const cfg of configs) {
+    for (const name of cfg.joints) {
+      const limit = cfg.jointLimits?.[name];
+      out.set(name, {
+        limit,
+        mapping: limit?.mapping ?? DEFAULT_ACTUATOR_MAPPING,
+      });
+    }
+  }
+  return out;
+}

--- a/src/features/hardwareConfiguration/ConfigurationPage.tsx
+++ b/src/features/hardwareConfiguration/ConfigurationPage.tsx
@@ -9,7 +9,6 @@ import { UI_CARD_SURFACE_STYLE, UI_PRIMARY_GREEN_BUTTON_STYLE } from '../../Cons
 import './configuration.switch.css';
 import { ActivateConfigureWorkflowModal } from './components/ActivateConfigureWorkflowModal.tsx';
 import { useHardwareConfiguration } from './hooks/useHardwareConfiguration.tsx';
-import { freePhysicalPinsOnBoard } from './model/documentHelpers.ts';
 
 const { Text } = Typography;
 
@@ -221,6 +220,7 @@ const ConfigurationPage = () => {
                 workflowLastRunDiff={hw.workflowLastRunDiff}
                 gazeboRunning={hw.gazeboRunning}
                 canRun={hw.modalCanRun && hw.isConnected}
+                generatedFileNames={hw.generatedFileNames}
             />
 
             {hw.yamlDoc ? (
@@ -248,35 +248,23 @@ const ConfigurationPage = () => {
                                     style={{ width: 200 }}
                                     allowClear
                                 />
-                                <Select
+                                <Button
+                                    type="default"
                                     size="small"
-                                    placeholder="BOARD"
-                                    style={{ minWidth: 200 }}
+                                    className="hardware-config-add-btn"
                                     disabled={
                                         editorLocked ||
                                         !hw.yamlDoc ||
                                         hw.boardsEligibleForNewActuator.length === 0
                                     }
-                                    value={hw.addActuatorBoard}
-                                    options={hw.boardsEligibleForNewActuator.map((b) => ({
-                                        value: b,
-                                        label: `${b} (${
-                                            hw.yamlDoc ? freePhysicalPinsOnBoard(hw.yamlDoc, b).length : 0
-                                        } free)`,
-                                    }))}
-                                    onChange={(v) => hw.setAddActuatorBoard(v)}
-                                />
-                                <Button
-                                    type="default"
-                                    size="small"
-                                    className="hardware-config-add-btn"
-                                    disabled={editorLocked || !hw.yamlDoc || !hw.addActuatorBoard}
                                     onClick={hw.handleAddActuator}
                                     style={{ minWidth: 132 }}
                                     title={
-                                        !hw.yamlDoc || !hw.addActuatorBoard
-                                            ? 'Choose a board with a free pin, then add an actuator.'
-                                            : undefined
+                                        !hw.yamlDoc
+                                            ? 'Load a hardware configuration first.'
+                                            : hw.boardsEligibleForNewActuator.length === 0
+                                                ? 'No board has a free physical pin.'
+                                                : 'Add a row on the first board with a free pin — change the board on the new row if needed.'
                                     }
                                 >
                                     <Space size={6}>

--- a/src/features/hardwareConfiguration/activateWorkflowStepTypes.ts
+++ b/src/features/hardwareConfiguration/activateWorkflowStepTypes.ts
@@ -1,4 +1,4 @@
-export type WorkflowStepId = 'validate' | 'activate' | 'build' | 'flash' | 'reload';
+export type WorkflowStepId = 'validate' | 'activate' | 'generate' | 'build' | 'flash' | 'reload';
 
 export type WorkflowStepRuntimeStatus = 'pending' | 'running' | 'done' | 'error' | 'skipped';
 

--- a/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
+++ b/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
@@ -8,6 +8,7 @@ import {
 } from '@ant-design/icons';
 import { Alert, Button, Card, Checkbox, Divider, Modal, Progress, Space, Switch, Tag, Typography } from 'antd';
 import type { HardwareConfigDiff } from '../model/hardwareConfigDiff.ts';
+import type { GeneratedFileNames } from '../../../Utils/generatedFiles.ts';
 import { HardwareConfigPresetHeaderTag } from '../../../Components/HardwareConfigPresetTag.tsx';
 import {
     UI_ACCENT_GREEN,
@@ -85,6 +86,12 @@ export interface ActivateConfigureWorkflowModalProps {
      */
     gazeboRunning: boolean | null;
     canRun: boolean;
+    /**
+     * Generated-artifact filenames resolved from the active hardware doc
+     * (`generated_files` in the YAML). Keeps the regenerate copy in sync with
+     * what the pipeline actually writes instead of hardcoding names.
+     */
+    generatedFileNames: GeneratedFileNames;
 }
 
 export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowModalProps) {
@@ -114,6 +121,7 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
         workflowLastRunDiff,
         gazeboRunning,
         canRun,
+        generatedFileNames,
     } = props;
 
     const showGazeboRestartPrompt =
@@ -169,7 +177,19 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                         onChange={onActivateModalSimulationOnlyChange}
                         disabled={workflowRunning || pipelineBoardOptions.length === 0}
                     />
-                    <Text style={{ marginLeft: 8 }}>SIMULATION ONLY (NO HARDWARE BUILD / FLASH)</Text>
+                    <Text style={{ marginLeft: 8 }}>
+                        SIMULATION ONLY (ROS2_CONTROL + RELOAD, NO FIRMWARE BUILD / FLASH)
+                    </Text>
+                    {activateModalSimulationOnly ? (
+                        <Text
+                            type="secondary"
+                            style={{ display: 'block', marginTop: 6, marginLeft: 28, fontSize: 12 }}
+                        >
+                            Regenerates {generatedFileNames.ros2ControlXacro} and{' '}
+                            {generatedFileNames.controllersYaml}, then reloads the
+                            control stack — no firmware build or flash.
+                        </Text>
+                    ) : null}
                 </div>
 
                 {!activateModalSimulationOnly ? (
@@ -214,6 +234,10 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                     />
                     <Text style={{ marginLeft: 8 }}>BUILD ONLY (NO FLASH)</Text>
                 </div>
+                <Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+                    ros2_control and controllers are regenerated before firmware build (same as simulation,
+                    plus BUILD / FLASH when selected).
+                </Text>
                 </>
                 ) : null}
 
@@ -245,15 +269,15 @@ export function ActivateConfigureWorkflowModal(props: ActivateConfigureWorkflowM
                         style={{
                             display: 'grid',
                             gridTemplateColumns: activateModalSimulationOnly
-                                ? 'repeat(3, 1fr)'
-                                : 'repeat(5, 1fr)',
+                                ? 'repeat(2, 1fr)'
+                                : 'repeat(3, 1fr)',
                             gap: 8,
                             marginTop: 12,
                         }}
                     >
                         {(activateModalSimulationOnly
-                            ? (['validate', 'activate', 'reload'] as const)
-                            : (['validate', 'activate', 'build', 'flash', 'reload'] as const)
+                            ? (['validate', 'activate', 'generate', 'reload'] as const)
+                            : (['validate', 'activate', 'generate', 'build', 'flash', 'reload'] as const)
                         )
                             .map((id) => workflowSteps.find((s) => s.id === id))
                             .filter((s): s is NonNullable<typeof s> => s != null)

--- a/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
+++ b/src/features/hardwareConfiguration/hooks/useActivateConfigureWorkflow.tsx
@@ -18,36 +18,59 @@ function initialSteps(
     buildOnly: boolean,
     activateOnly: boolean,
 ): WorkflowStepSlice[] {
+    const skippedBuildFlash = simulationOnly
+        ? [
+              {
+                  id: 'build' as const,
+                  title: 'BUILD',
+                  status: 'skipped' as const,
+                  fraction: 0,
+                  detail: 'Skipped (simulation only)',
+              },
+              {
+                  id: 'flash' as const,
+                  title: 'FLASH',
+                  status: 'skipped' as const,
+                  fraction: 0,
+                  detail: 'Skipped (simulation only)',
+              },
+          ]
+        : [];
+
     if (simulationOnly) {
         return [
             { id: 'validate', title: 'VALIDATE', status: 'pending', fraction: 0, detail: '' },
             { id: 'activate', title: 'ACTIVATE', status: 'pending', fraction: 0, detail: '' },
+            {
+                id: 'generate',
+                title: 'GENERATE',
+                status: 'pending',
+                fraction: 0,
+                detail: 'ros2_control + controllers',
+            },
             { id: 'reload', title: 'RELOAD', status: 'pending', fraction: 0, detail: '' },
-            {
-                id: 'build',
-                title: 'BUILD',
-                status: 'skipped',
-                fraction: 0,
-                detail: 'Skipped (simulation only)',
-            },
-            {
-                id: 'flash',
-                title: 'FLASH',
-                status: 'skipped',
-                fraction: 0,
-                detail: 'Skipped (simulation only)',
-            },
+            ...skippedBuildFlash,
         ];
     }
+
     return [
         { id: 'validate', title: 'VALIDATE', status: 'pending', fraction: 0, detail: '' },
         { id: 'activate', title: 'ACTIVATE', status: 'pending', fraction: 0, detail: '' },
+        {
+            id: 'generate',
+            title: 'GENERATE',
+            status: activateOnly ? 'skipped' : 'pending',
+            fraction: 0,
+            detail: activateOnly
+                ? 'Skipped (activate only)'
+                : 'ros2_control + controllers (before firmware build)',
+        },
         {
             id: 'build',
             title: 'BUILD',
             status: activateOnly ? 'skipped' : 'pending',
             fraction: 0,
-            detail: activateOnly ? 'Skipped (activate only)' : '',
+            detail: activateOnly ? 'Skipped (activate only)' : 'Firmware only',
         },
         {
             id: 'flash',
@@ -60,7 +83,13 @@ function initialSteps(
                   ? 'Skipped (activate only)'
                   : '',
         },
-        { id: 'reload', title: 'RELOAD', status: 'pending', fraction: 0, detail: '' },
+        {
+            id: 'reload',
+            title: 'RELOAD',
+            status: activateOnly ? 'skipped' : 'pending',
+            fraction: 0,
+            detail: activateOnly ? 'Skipped (activate only)' : '',
+        },
     ];
 }
 
@@ -79,14 +108,6 @@ export function computeWorkflowOverallPercent(steps: WorkflowStepSlice[]): numbe
     return Math.round(sum * 100);
 }
 
-function fractionForBuildAggregate(f: ConfigurePipelineFeedbackNormalized): number {
-    const p = f.phase?.toLowerCase() ?? '';
-    if (p === 'validate') return Math.max(0, Math.min(1, f.progress * 0.2));
-    if (p === 'generate') return Math.max(0, Math.min(1, 0.2 + f.progress * 0.35));
-    if (p === 'build') return Math.max(0, Math.min(1, 0.55 + f.progress * 0.45));
-    return Math.max(0, Math.min(1, f.progress));
-}
-
 function fractionForValidateDryRun(f: ConfigurePipelineFeedbackNormalized): number {
     const p = f.phase?.toLowerCase() ?? '';
     if (p === 'validate') return Math.max(0, Math.min(1, f.progress * 0.55));
@@ -94,12 +115,16 @@ function fractionForValidateDryRun(f: ConfigurePipelineFeedbackNormalized): numb
     return Math.max(0, Math.min(1, f.progress));
 }
 
-function fractionForWetSim(f: ConfigurePipelineFeedbackNormalized): number {
+function fractionForGeneratePhase(f: ConfigurePipelineFeedbackNormalized): number {
     const p = f.phase?.toLowerCase() ?? '';
-    if (p === 'validate') return Math.max(0, Math.min(1, f.progress * 0.25));
-    if (p === 'generate') return Math.max(0, Math.min(1, 0.25 + f.progress * 0.35));
-    if (p === 'reload') return Math.max(0, Math.min(1, 0.6 + f.progress * 0.4));
-    return Math.max(0, Math.min(1, f.progress));
+    if (p === 'generate') return Math.max(0, Math.min(1, f.progress));
+    return 0;
+}
+
+function fractionForBuildPhase(f: ConfigurePipelineFeedbackNormalized): number {
+    const p = f.phase?.toLowerCase() ?? '';
+    if (p === 'build') return Math.max(0, Math.min(1, f.progress));
+    return 0;
 }
 
 export interface UseActivateConfigureWorkflowParams {
@@ -284,6 +309,11 @@ export function useActivateConfigureWorkflow({
                 await refetchActiveHardware();
 
                 if (activateOnly && !simulationOnly) {
+                    patchStep('generate', {
+                        status: 'skipped',
+                        fraction: 0,
+                        detail: 'Skipped (activate only)',
+                    });
                     patchStep('build', {
                         status: 'skipped',
                         fraction: 0,
@@ -299,16 +329,17 @@ export function useActivateConfigureWorkflow({
                         fraction: 0,
                         detail: 'Skipped (activate only)',
                     });
-                    setDetailLine('Activated — build, flash, and reload skipped.');
+                    setDetailLine('Activated — generate, build, flash, and reload skipped.');
                     await refetchActiveHardware();
-                    messageApi.success('Configuration activated (build, flash, and reload skipped).');
+                    messageApi.success('Configuration activated (generate, build, flash, and reload skipped).');
                     computeAndStoreDiff();
                     setLastRunSucceeded(true);
                     return;
                 }
 
+                patchStep('generate', { status: 'running', fraction: 0, detail: '' });
                 if (!simulationOnly) {
-                    patchStep('build', { status: 'running', fraction: 0, detail: '' });
+                    patchStep('build', { status: 'pending', fraction: 0, detail: '' });
                     if (!buildOnly) {
                         patchStep('flash', { status: 'pending', fraction: 0, detail: '' });
                     }
@@ -316,10 +347,12 @@ export function useActivateConfigureWorkflow({
                 patchStep('reload', { status: 'pending', fraction: 0, detail: '' });
                 setDetailLine(
                     simulationOnly
-                        ? 'SIMULATION — generate sim ros2_control and reload…'
-                        : 'BUILD — pipeline on active mapping…',
+                        ? 'GENERATE — ros2_control + controllers, then reload…'
+                        : 'GENERATE — ros2_control + controllers, then firmware build / flash…',
                 );
 
+                let sawGenerate = false;
+                let sawBuild = false;
                 let sawFlash = false;
                 let sawReload = false;
                 const wet = startConfigurePipeline(
@@ -339,6 +372,7 @@ export function useActivateConfigureWorkflow({
 
                             if (phase === 'reload') {
                                 sawReload = true;
+                                patchStep('generate', { status: 'done', fraction: 1, detail: 'OK' });
                                 if (!simulationOnly) {
                                     patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
                                     if (buildOnly) {
@@ -358,22 +392,26 @@ export function useActivateConfigureWorkflow({
                                 });
                             } else if (phase === 'flash') {
                                 sawFlash = true;
+                                patchStep('generate', { status: 'done', fraction: 1, detail: 'OK' });
                                 patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
                                 patchStep('flash', {
                                     status: 'running',
                                     fraction: Math.max(0, Math.min(1, f.progress)),
                                     detail: f.detail || phase,
                                 });
-                            } else if (simulationOnly) {
-                                patchStep('reload', {
-                                    status: 'running',
-                                    fraction: fractionForWetSim(f),
-                                    detail: f.detail || phase,
-                                });
-                            } else {
+                            } else if (phase === 'build') {
+                                sawBuild = true;
+                                patchStep('generate', { status: 'done', fraction: 1, detail: 'OK' });
                                 patchStep('build', {
                                     status: 'running',
-                                    fraction: fractionForBuildAggregate(f),
+                                    fraction: fractionForBuildPhase(f),
+                                    detail: f.detail || phase,
+                                });
+                            } else if (phase === 'generate') {
+                                sawGenerate = true;
+                                patchStep('generate', {
+                                    status: 'running',
+                                    fraction: fractionForGeneratePhase(f),
                                     detail: f.detail || phase,
                                 });
                             }
@@ -388,12 +426,24 @@ export function useActivateConfigureWorkflow({
 
                 if (!wetRes.success) {
                     const msg = wetRes.message || 'Configure pipeline failed';
-                    if (simulationOnly && sawReload) failStep('reload', msg);
-                    else if (buildOnly || !sawFlash) failStep('build', msg);
-                    else failStep('flash', msg);
+                    if (simulationOnly) {
+                        if (sawReload) failStep('reload', msg);
+                        else failStep('generate', msg);
+                    } else if (sawReload) {
+                        failStep('reload', msg);
+                    } else if (sawFlash) {
+                        failStep('flash', msg);
+                    } else if (sawBuild) {
+                        failStep('build', msg);
+                    } else if (sawGenerate) {
+                        failStep('generate', msg);
+                    } else {
+                        failStep('generate', msg);
+                    }
                     return;
                 }
 
+                patchStep('generate', { status: 'done', fraction: 1, detail: 'OK' });
                 if (!simulationOnly) {
                     patchStep('build', { status: 'done', fraction: 1, detail: 'OK' });
                     if (buildOnly) {

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigEditor.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigEditor.tsx
@@ -27,7 +27,7 @@ export function useHardwareConfigEditor(params: HardwareConfigEditorParams) {
         yamlDoc: yaml.yamlDoc,
         patchDoc: yaml.patchDoc,
         messageApi: params.messageApi,
-        addActuatorBoard: table.addActuatorBoard,
+        boardsEligibleForNewActuator: table.boardsEligibleForNewActuator,
         addPressureSensorActuatorId: table.addPressureSensorActuatorId,
     });
 
@@ -84,8 +84,6 @@ export function useHardwareConfigEditor(params: HardwareConfigEditorParams) {
         boardRows: table.boardRows,
         boardsEligibleForNewActuator: table.boardsEligibleForNewActuator,
         actuatorsEligibleForNewPressureSensor: table.actuatorsEligibleForNewPressureSensor,
-        addActuatorBoard: table.addActuatorBoard,
-        setAddActuatorBoard: table.setAddActuatorBoard,
         addPressureSensorActuatorId: table.addPressureSensorActuatorId,
         setAddPressureSensorActuatorId: table.setAddPressureSensorActuatorId,
         actuatorSearchQuery: table.actuatorSearchQuery,

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigMutations.ts
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigMutations.ts
@@ -12,7 +12,13 @@ export interface HardwareConfigMutationsParams {
     yamlDoc: Record<string, unknown> | null;
     patchDoc: (next: Record<string, unknown>) => void;
     messageApi: MessageInstance;
-    addActuatorBoard: string | undefined;
+    /**
+     * Board ids ordered as in the YAML that still have at least one free
+     * physical pin. The new-actuator row is created on the first entry; the
+     * user picks a different board (or pin) from the row's BOARD column
+     * once the row is in the table.
+     */
+    boardsEligibleForNewActuator: string[];
     addPressureSensorActuatorId: string | undefined;
 }
 
@@ -20,12 +26,17 @@ export function useHardwareConfigMutations({
     yamlDoc,
     patchDoc,
     messageApi,
-    addActuatorBoard,
+    boardsEligibleForNewActuator,
     addPressureSensorActuatorId,
 }: HardwareConfigMutationsParams) {
     const handleAddActuator = useCallback(() => {
-        if (!yamlDoc || !addActuatorBoard) return;
-        const row = defaultNewActuatorRow(yamlDoc, addActuatorBoard);
+        if (!yamlDoc) return;
+        const targetBoard = boardsEligibleForNewActuator[0];
+        if (!targetBoard) {
+            messageApi.warning('No board has a free physical pin.');
+            return;
+        }
+        const row = defaultNewActuatorRow(yamlDoc, targetBoard);
         if (!row) {
             messageApi.warning('No free physical pin on that board.');
             return;
@@ -34,8 +45,8 @@ export function useHardwareConfigMutations({
         if (!Array.isArray(next.actuators)) next.actuators = [];
         (next.actuators as Record<string, unknown>[]).push(row);
         patchDoc(next);
-        messageApi.success(`Added actuator "${String(row.id)}"`);
-    }, [yamlDoc, addActuatorBoard, patchDoc, messageApi]);
+        messageApi.success(`Added actuator "${String(row.id)}" on ${targetBoard}`);
+    }, [yamlDoc, boardsEligibleForNewActuator, patchDoc, messageApi]);
 
     const handleAddPressureSensor = useCallback(() => {
         if (!yamlDoc || !addPressureSensorActuatorId) return;

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfigTableModel.ts
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfigTableModel.ts
@@ -12,7 +12,6 @@ import type { ActuatorTableRecord, BoardRow, PressureSensorTableRecord } from '.
  * Table row projections and “add actuator / sensor” dropdown options derived from the current YAML doc.
  */
 export function useHardwareConfigTableModel(yamlDoc: Record<string, unknown> | null) {
-    const [addActuatorBoard, setAddActuatorBoard] = useState<string | undefined>();
     const [addPressureSensorActuatorId, setAddPressureSensorActuatorId] = useState<string | undefined>();
     const [actuatorSearchQuery, setActuatorSearchQuery] = useState('');
 
@@ -37,12 +36,6 @@ export function useHardwareConfigTableModel(yamlDoc: Record<string, unknown> | n
     }, [yamlDoc]);
 
     useEffect(() => {
-        setAddActuatorBoard((prev) =>
-            prev && boardsEligibleForNewActuator.includes(prev) ? prev : boardsEligibleForNewActuator[0],
-        );
-    }, [boardsEligibleForNewActuator]);
-
-    useEffect(() => {
         setAddPressureSensorActuatorId((prev) =>
             prev && actuatorsEligibleForNewPressureSensor.some((o) => o.value === prev)
                 ? prev
@@ -65,7 +58,7 @@ export function useHardwareConfigTableModel(yamlDoc: Record<string, unknown> | n
                 serial_id: b && typeof b.serial_id === 'string' ? b.serial_id : '',
                 board_class: b && typeof b.board_class === 'string' ? b.board_class : '',
                 firmware_target: b && typeof b.firmware_target === 'string' ? b.firmware_target : '',
-                internalServoSlots: slots,
+                internalActuatorSlots: slots,
                 attachedPins,
             };
         });
@@ -121,8 +114,6 @@ export function useHardwareConfigTableModel(yamlDoc: Record<string, unknown> | n
         pressureSensorRows,
         hardwareRobotName,
         assignableUrdfJoints,
-        addActuatorBoard,
-        setAddActuatorBoard,
         addPressureSensorActuatorId,
         setAddPressureSensorActuatorId,
         actuatorSearchQuery,

--- a/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
+++ b/src/features/hardwareConfiguration/hooks/useHardwareConfiguration.tsx
@@ -1,12 +1,54 @@
-import { message } from 'antd';
+import { Modal, message } from 'antd';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useActiveHardwareRos } from '../../../contexts/ActiveHardwareRosContext.tsx';
 import { useGazeboRunning } from '../../../hooks/useGazeboRunning.hook.ts';
 import { useRosConnection } from '../../../hooks/useRosConnection.hook.ts';
+import { HardwareConfigHandler } from '../../../Services/ros/handlers/HardwareConfig.handler.ts';
+import { parseHardwareConfigYaml } from '../../../Utils/hardwareConfigYaml.ts';
+import { resolveGeneratedFiles } from '../../../Utils/generatedFiles.ts';
+import { computeHardwareConfigDiff } from '../model/hardwareConfigDiff.ts';
 import { boardsToFlashGoal } from '../utils/boardsToFlashGoal.ts';
 import { useActivateConfigureWorkflow } from './useActivateConfigureWorkflow.tsx';
 import { useHardwareConfigEditor } from './useHardwareConfigEditor.tsx';
 import { useHardwareConfigLists } from './useHardwareConfigLists.ts';
+
+/**
+ * Show a blocking confirm dialog listing actuators that will switch from
+ * disabled to enabled by the activation. Resolves to `true` if the user
+ * accepts driving real hardware, `false` otherwise.
+ */
+function confirmNewlyEnabled(
+    newlyEnabled: { actuatorId: string; label: string }[],
+): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        Modal.confirm({
+            title: 'ENABLE ACTUATORS ON REAL HARDWARE?',
+            icon: <ExclamationCircleOutlined />,
+            content: (
+                <div>
+                    <p style={{ marginTop: 0 }}>
+                        Activating this configuration will start driving the following
+                        actuator{newlyEnabled.length === 1 ? '' : 's'} on the real robot.
+                        Make sure the hardware is powered, clear of obstacles, and that
+                        joint limits / calibration are correct.
+                    </p>
+                    <ul style={{ maxHeight: 220, overflow: 'auto', paddingLeft: 18 }}>
+                        {newlyEnabled.map((a) => (
+                            <li key={a.actuatorId}>{a.label}</li>
+                        ))}
+                    </ul>
+                </div>
+            ),
+            okText: 'ENABLE & RUN',
+            okType: 'danger',
+            cancelText: 'CANCEL',
+            centered: true,
+            onOk: () => resolve(true),
+            onCancel: () => resolve(false),
+        });
+    });
+}
 
 export function useHardwareConfiguration() {
     const { isConnected } = useRosConnection();
@@ -177,12 +219,56 @@ export function useHardwareConfiguration() {
         [],
     );
 
+    /**
+     * Returns the list of actuators that will transition disabled→enabled (or
+     * arrive newly already-enabled) when `targetConfigName` is activated, by
+     * diffing it against the currently-active doc the supervisor reported.
+     * Returns `null` when the diff cannot be computed (no active snapshot,
+     * fetch failure, or unparseable YAML) so the caller can choose to
+     * proceed without prompting.
+     */
+    const detectNewlyEnabledActuators = useCallback(
+        async (
+            targetConfigName: string,
+        ): Promise<{ actuatorId: string; label: string }[] | null> => {
+            const active = activeHardwareDocRef.current;
+            if (!active) return null;
+            try {
+                const res = await HardwareConfigHandler.getConfig(targetConfigName);
+                if (!res.success) return null;
+                const target = parseHardwareConfigYaml(res.config_yaml || '');
+                const diff = computeHardwareConfigDiff(active, target);
+                return diff.actuatorsNewlyEnabled;
+            } catch {
+                return null;
+            }
+        },
+        [],
+    );
+
     const runWorkflowFromModal = useCallback(async () => {
         const name = editor.loadConfigName.trim();
         if (!name) return;
         const simulationOnly = activateModalSimulationOnly || pipelineBoardIds.length === 0;
         const flashBoards = simulationOnly ? [] : boardsToFlashGoal(activateModalBoards, pipelineBoardIds);
         const noBoardsSelected = !simulationOnly && pipelineBoardIds.length > 0 && activateModalBoards.length === 0;
+
+        // Hardware-mode safety: if this run will newly enable actuators
+        // (disabled→enabled transition, or net-new row already enabled) and
+        // the flow is not simulation-only, surface a confirmation before any
+        // pipeline call so the user explicitly opts in to driving real motors.
+        if (!simulationOnly) {
+            const newlyEnabled = await detectNewlyEnabledActuators(name);
+            if (newlyEnabled === null) {
+                // Could not compute diff (target fetch failed, parse error, no
+                // active doc); fall through and let validate/activate surface
+                // any real problem rather than blocking on a soft check.
+            } else if (newlyEnabled.length > 0) {
+                const confirmed = await confirmNewlyEnabled(newlyEnabled);
+                if (!confirmed) return;
+            }
+        }
+
         await runActivateWorkflow({
             targetConfigName: name,
             boardsToFlash: flashBoards,
@@ -196,11 +282,19 @@ export function useHardwareConfiguration() {
         activateModalActivateOnly,
         activateModalBuildOnly,
         activateModalSimulationOnly,
+        detectNewlyEnabledActuators,
         editor.loadConfigName,
         editor.refreshConfigListForModal,
         pipelineBoardIds,
         runActivateWorkflow,
     ]);
+
+    // Names the pipeline will write for this preset (active doc is the source of
+    // truth); used only to keep the activate-workflow copy accurate.
+    const generatedFileNames = useMemo(
+        () => resolveGeneratedFiles(activeHardwareDoc),
+        [activeHardwareDoc],
+    );
 
     const modalCanRun =
         Boolean(editor.selectedTargetConfigName.trim()) &&
@@ -239,6 +333,7 @@ export function useHardwareConfiguration() {
         workflowLastRunDiff,
         gazeboRunning,
         modalCanRun,
+        generatedFileNames,
         pipelineBoardOptions,
         editorLocked,
         serverFlashedConfigName,

--- a/src/features/hardwareConfiguration/model/documentHelpers.ts
+++ b/src/features/hardwareConfiguration/model/documentHelpers.ts
@@ -1,4 +1,9 @@
 import type { CellErrorOpts } from '../../../Utils/hardwareConfigServerErrors.ts';
+import {
+    DEFAULT_ACTUATOR_TYPE_FALLBACK,
+    DEFAULT_NEW_ACTUATOR_VALUES,
+    DEFAULT_NEW_PRESSURE_SENSOR_VALUES,
+} from '../../../Constants/hardwareConfigDefaults.ts';
 import { listIgnoreUrdfJoints, listPassiveUrdfJoints } from './passiveUrdf.ts';
 
 export function asMapping(v: unknown): Record<string, unknown> | null {
@@ -30,9 +35,9 @@ export function boardRowOpts(boardId: string): CellErrorOpts {
     return { rowPrefix: `boards.${boardId}` };
 }
 
-export function normalizeServoType(raw: unknown): string {
+export function normalizeActuatorType(raw: unknown): string {
     const s = String(raw ?? '').trim().replace(/^["']|["']$/g, '');
-    return s || '270';
+    return s || DEFAULT_ACTUATOR_TYPE_FALLBACK;
 }
 
 export function sortedBoardIds(doc: Record<string, unknown>): string[] {
@@ -117,7 +122,7 @@ export function usedPhysicalPinsOnBoard(doc: Record<string, unknown>, boardId: s
     return usedPhysicalPinsOnBoardExcluding(doc, boardId, {});
 }
 
-/** Available physical connector indices `1..slots` (`internal_servo_slots`), excluding pins taken by other rows. */
+/** Available physical connector indices `1..slots` (`internal_servo_slots` YAML key), excluding pins taken by other rows. */
 export function physicalPinOptions(slots: number, usedElsewhere: Set<number>, currentPin: number): number[] {
     const opts: number[] = [];
     const cur = Number.isFinite(currentPin) ? currentPin : 1;
@@ -127,7 +132,7 @@ export function physicalPinOptions(slots: number, usedElsewhere: Set<number>, cu
     return opts;
 }
 
-/** Servo indices `1..internal_servo_slots` not claimed by an actuator or sensor on this board. */
+/** Physical pin indices `1..internal_servo_slots` not claimed by an actuator or sensor on this board. */
 export function freePhysicalPinsOnBoard(doc: Record<string, unknown>, boardId: string): number[] {
     const slots = boardSlots(doc, boardId);
     if (slots <= 0) return [];
@@ -223,14 +228,7 @@ export function defaultNewActuatorRow(doc: Record<string, unknown>, boardId: str
         board: boardId,
         virtual_pin: vp,
         physical_pin: pins[0],
-        servo_type: '270',
-        offset_deg: 0,
-        direction: 1,
-        scale: 1,
-        servo_min_deg: 0,
-        servo_max_deg: 270,
-        servo_default_deg: 135,
-        enabled: false,
+        ...DEFAULT_NEW_ACTUATOR_VALUES,
     };
 }
 
@@ -249,14 +247,14 @@ export function defaultNewPressureSensorRow(
     const id = uniquePressureSensorId(doc, boardId, vp);
     return {
         id,
-        type: 'pressure',
+        type: DEFAULT_NEW_PRESSURE_SENSOR_VALUES.type,
         associated_actuator: associatedActuatorId,
         board: boardId,
         virtual_pin: vp,
         physical_pin: pins[0],
-        min_value: null,
-        max_value: null,
-        enabled: true,
+        min_value: DEFAULT_NEW_PRESSURE_SENSOR_VALUES.min_value,
+        max_value: DEFAULT_NEW_PRESSURE_SENSOR_VALUES.max_value,
+        enabled: DEFAULT_NEW_PRESSURE_SENSOR_VALUES.enabled,
     };
 }
 

--- a/src/features/hardwareConfiguration/model/hardwareConfigDiff.ts
+++ b/src/features/hardwareConfiguration/model/hardwareConfigDiff.ts
@@ -6,17 +6,23 @@
  * `gz_ros2_control` plugin reads at robot spawn requires a Gazebo restart (the
  * plugin only loads URDF + ros2_control blocks once per spawn).
  *
- * Server-side ros2_control template fields ⇒ included in the diff:
+ * Server-side ros2_control template fields ⇒ included in the Gazebo-restart diff:
  *   - board (per actuator)
  *   - urdf_joint (per actuator)
- *   - virtual_pin, servo_type, offset_deg, direction, scale,
- *     servo_min_deg, servo_max_deg, servo_default_deg (per actuator)
+ *   - virtual_pin, servo_type (YAML), offset_deg, direction, scale,
+ *     servo_min_deg, servo_max_deg, servo_default_deg (per actuator, YAML keys)
  *
- * NOT included (firmware-only or runtime-only):
- *   - actuator.enabled (firmware emits, but ros2_control still exports the joint)
+ * NOT included in the Gazebo-restart decision:
  *   - sensors (firmware only)
  *   - passive_urdf_joints / ignore_urdf_joints (controllers.yaml only,
  *     applied by RELOAD without Gazebo restart)
+ *
+ * `actuator.enabled` is tracked separately as `actuatorsNewlyEnabled`: a
+ * disabled→enabled transition (or a freshly added row already enabled) means
+ * the next pipeline run will start driving real motors, which warrants a
+ * confirmation prompt before activation in non-simulation flows. It does NOT
+ * change `requiresGazeboRestart`: ros2_control still exports the joint either
+ * way, only firmware C inclusion flips.
  */
 
 import { asMapping } from './documentHelpers.ts';
@@ -57,11 +63,21 @@ export interface HardwareConfigDiff {
     actuatorsRemoved: { actuatorId: string; label: string }[];
     /** Actuators in both, but with at least one ros2_control field changed. */
     actuatorsModified: ActuatorDiffEntry[];
+    /**
+     * Actuators that flip from disabled to `enabled=true` in target (missing
+     * `enabled` counts as disabled). These rows will start driving real servos
+     * on next firmware build/flash; surface a confirmation before activation
+     * outside simulation-only mode.
+     */
+    actuatorsNewlyEnabled: { actuatorId: string; label: string }[];
     /** Boards added in target. */
     boardsAdded: string[];
     /** Boards removed in target. */
     boardsRemoved: string[];
-    /** True if any of the above lists is non-empty. */
+    /**
+     * True if any ros2_control / board structural change is present.
+     * `actuatorsNewlyEnabled` does NOT count here (firmware-only flip).
+     */
     requiresGazeboRestart: boolean;
 }
 
@@ -92,12 +108,18 @@ function actuatorLabel(a: Actuator, fallbackId: string): string {
 }
 
 function valuesDiffer(before: unknown, after: unknown): boolean {
-    // Treat missing/undefined and empty-string-only differences as equal where servo configs
+    // Treat missing/undefined and empty-string-only differences as equal where actuator configs
     // typically default; but for the comparison we err on "different" if either is set.
     if (before === after) return false;
     const bs = before === undefined || before === null ? '' : String(before);
     const as_ = after === undefined || after === null ? '' : String(after);
     return bs !== as_;
+}
+
+/** Only an explicit `enabled: true` counts as enabled; missing or false does not. */
+function isEnabled(a: Actuator | undefined): boolean {
+    if (!a) return false;
+    return a.enabled === true;
 }
 
 /**
@@ -120,10 +142,14 @@ export function computeHardwareConfigDiff(
     const actuatorsAdded: { actuatorId: string; label: string }[] = [];
     const actuatorsRemoved: { actuatorId: string; label: string }[] = [];
     const actuatorsModified: ActuatorDiffEntry[] = [];
+    const actuatorsNewlyEnabled: { actuatorId: string; label: string }[] = [];
 
     for (const [id, ta] of target) {
         if (!active.has(id)) {
             actuatorsAdded.push({ actuatorId: id, label: actuatorLabel(ta, id) });
+            if (isEnabled(ta)) {
+                actuatorsNewlyEnabled.push({ actuatorId: id, label: actuatorLabel(ta, id) });
+            }
         }
     }
     for (const [id, aa] of active) {
@@ -143,6 +169,9 @@ export function computeHardwareConfigDiff(
         if (changes.length > 0) {
             actuatorsModified.push({ actuatorId: id, label: actuatorLabel(ta, id), changes });
         }
+        if (!isEnabled(aa) && isEnabled(ta)) {
+            actuatorsNewlyEnabled.push({ actuatorId: id, label: actuatorLabel(ta, id) });
+        }
     }
 
     const boardsAdded: string[] = [];
@@ -161,6 +190,7 @@ export function computeHardwareConfigDiff(
         actuatorsAdded,
         actuatorsRemoved,
         actuatorsModified,
+        actuatorsNewlyEnabled,
         boardsAdded,
         boardsRemoved,
         requiresGazeboRestart,

--- a/src/features/hardwareConfiguration/tables/actuatorColumns.tsx
+++ b/src/features/hardwareConfiguration/tables/actuatorColumns.tsx
@@ -11,8 +11,9 @@ import type { ActuatorTableRecord } from '../types.ts';
 import {
     actOpts,
     boardSlots,
+    freePhysicalPinsOnBoard,
     jointSelectOptions,
-    normalizeServoType,
+    normalizeActuatorType,
     physicalPinOptions,
     sortedBoardIds,
     usedPhysicalPinsOnBoardExcluding,
@@ -178,6 +179,17 @@ export function buildActuatorColumns({
                 const ao = actOpts(id, 'board');
                 const curBoard = String(row.board ?? '');
                 const boardIds = yamlDoc ? sortedBoardIds(yamlDoc) : [];
+                // Free-pin counts mirror the "globally unused" definition the
+                // (now-removed) toolbar selector showed; the row's own board
+                // therefore reads (n-1 free) since this row already occupies
+                // one of its pins.
+                const boardOptions = boardIds.map((b) => {
+                    const free = yamlDoc ? freePhysicalPinsOnBoard(yamlDoc, b).length : 0;
+                    return {
+                        value: b,
+                        label: `${b} (${free} free)`,
+                    };
+                });
                 return (
                     <div title={cellTooltipText(serverFieldErrors, ao)}>
                         <Select
@@ -187,7 +199,7 @@ export function buildActuatorColumns({
                                 ...cellOutlineStyle(serverFieldErrors, ao, outlineBorders),
                             }}
                             value={curBoard || undefined}
-                            options={boardIds.map((b) => ({ value: b, label: b }))}
+                            options={boardOptions}
                             onChange={(boardVal) => {
                                 if (!yamlDoc) return;
                                 const next = structuredClone(yamlDoc);
@@ -284,13 +296,13 @@ export function buildActuatorColumns({
             },
         },
         {
-            title: 'SERVO_TYPE',
+            title: 'ACTUATOR_TYPE',
             key: 'servo_type',
             width: 120,
             render: (_: unknown, record: ActuatorTableRecord) => {
                 const { row, index } = record;
                 const id = String(row.id ?? index);
-                const v = normalizeServoType(row.servo_type);
+                const v = normalizeActuatorType(row.servo_type);
                 const ao = actOpts(id, 'servo_type');
                 return (
                     <div title={cellTooltipText(serverFieldErrors, ao)}>

--- a/src/features/hardwareConfiguration/tables/boardColumns.tsx
+++ b/src/features/hardwareConfiguration/tables/boardColumns.tsx
@@ -63,12 +63,12 @@ export function buildBoardColumns(
             render: (n: number, r: BoardRow) => (
                 <Text
                     style={{ fontFamily: 'monospace' }}
-                    title="Physical pins 1..internal_servo_slots claimed by actuators or sensors on this board"
+                    title="Physical pins 1..internal_actuator_slots claimed by actuators or sensors on this board"
                 >
                     {n}
-                    {r.internalServoSlots > 0 ? (
+                    {r.internalActuatorSlots > 0 ? (
                         <Text type="secondary" style={{ marginLeft: 4 }}>
-                            / {r.internalServoSlots}
+                            / {r.internalActuatorSlots}
                         </Text>
                     ) : null}
                 </Text>

--- a/src/features/hardwareConfiguration/types.ts
+++ b/src/features/hardwareConfiguration/types.ts
@@ -16,7 +16,7 @@ export interface BoardRow {
     serial_id: string;
     board_class: string;
     firmware_target: string;
-    internalServoSlots: number;
-    /** Distinct physical_pin values in 1..internal_servo_slots used by actuators or sensors on this board. */
+    internalActuatorSlots: number;
+    /** Distinct physical_pin values in 1..internal_servo_slots (YAML) used by actuators or sensors on this board. */
     attachedPins: number;
 }

--- a/src/hooks/useUrdfJointLimits.ts
+++ b/src/hooks/useUrdfJointLimits.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import ROSLIB from 'roslib';
+import { RosBridgeService } from '../Services/ros/ros.service';
+
+export interface UrdfJointLimitRad {
+  lowerRad: number;
+  upperRad: number;
+}
+
+/** Parse URDF XML for revolute/prismatic joint limits (radians). */
+export function parseUrdfJointLimits(urdfXml: string): Map<string, UrdfJointLimitRad> {
+  const out = new Map<string, UrdfJointLimitRad>();
+  if (!urdfXml.trim()) return out;
+
+  const doc = new DOMParser().parseFromString(urdfXml, 'text/xml');
+  const parseError = doc.querySelector('parsererror');
+  if (parseError) {
+    console.warn('useUrdfJointLimits: failed to parse robot_description XML');
+    return out;
+  }
+
+  const joints = doc.querySelectorAll('joint');
+  joints.forEach((jointEl) => {
+    const name = jointEl.getAttribute('name');
+    if (!name) return;
+    const type = jointEl.getAttribute('type');
+    if (type !== 'revolute' && type !== 'prismatic') return;
+
+    const limitEl = jointEl.querySelector('limit');
+    if (!limitEl) return;
+
+    const lower = Number(limitEl.getAttribute('lower'));
+    const upper = Number(limitEl.getAttribute('upper'));
+    if (!Number.isFinite(lower) || !Number.isFinite(upper) || lower >= upper) return;
+
+    out.set(name, { lowerRad: lower, upperRad: upper });
+  });
+
+  return out;
+}
+
+/**
+ * Subscribe to latched /robot_description and expose URDF joint limits in radians.
+ */
+export function useUrdfJointLimits(isConnected: boolean): Map<string, UrdfJointLimitRad> {
+  const [limits, setLimits] = useState<Map<string, UrdfJointLimitRad>>(() => new Map());
+
+  useEffect(() => {
+    if (!isConnected) {
+      setLimits(new Map());
+      return;
+    }
+
+    const ros = RosBridgeService.getInstance().rosConnection;
+    if (!ros) return;
+
+    const topic = new ROSLIB.Topic({
+      ros,
+      name: '/robot_description',
+      messageType: 'std_msgs/msg/String',
+    });
+
+    const onMessage = (msg: ROSLIB.Message) => {
+      const data = (msg as unknown as { data?: string }).data;
+      if (typeof data !== 'string' || !data.trim()) return;
+      setLimits(parseUrdfJointLimits(data));
+    };
+
+    topic.subscribe(onMessage);
+    return () => topic.unsubscribe();
+  }, [isConnected]);
+
+  return limits;
+}


### PR DESCRIPTION
**Summary**

- New `'generate'` workflow step (`WorkflowStepId`) wired through `useActivateConfigureWorkflow` (initial steps, fractional progress, feedback, error reporting) and rendered in `ActivateConfigureWorkflowModal` (4 steps in *SIMULATION ONLY*, 6 in hardware mode).
- Refined modal copy for *SIMULATION ONLY* and *BUILD ONLY* so users can tell when the pipeline rewrites `ros2_control` xacro / `controllers.yaml` versus when it also builds/flashes firmware.
- Documentation: `README.md` features list mentions hardware-envelope sliders and the activate workflow; `docs/architecture/overview.md` gains a unit-conversion table along the joint-control path and a phase table for the modal; `docs/services/ros/handlers/JointState.handler.md` notes that clamping is downstream in `LucySystemHardware`.