### PR TITLE
feat(stream): list cameras from active hardware config and probe publishers

### DIFF
--- a/src/Components/StreamPlayerModal.tsx
+++ b/src/Components/StreamPlayerModal.tsx
@@ -35,6 +35,17 @@ const SELECT_POPUP_STYLE = {
     }
 };
 
+function isStreamSourceAvailable(
+    source: StreamSource,
+    availableTopics: Set<string> | null,
+): boolean {
+    return (
+        source.virtual === true ||
+        availableTopics === null ||
+        availableTopics.has(source.topic)
+    );
+}
+
 interface StreamPlayerModalProps {
     isVisible: boolean;
     onClose: () => void;
@@ -75,10 +86,6 @@ export function StreamPlayerModal({
     // Camera topics with a live publisher (null = unknown → assume available).
     const availableTopics = useAvailableTopics(cameraTopics, isVisible);
 
-    // Selectable if virtual, has a publisher, or availability is still unknown.
-    const isSourceAvailable = (source: StreamSource): boolean =>
-        source.virtual === true || availableTopics === null || availableTopics.has(source.topic);
-
     const handleStreamSourceChange = (value: string) => {
         const source = streamSources.find(s => s.id === value);
         if (source) {
@@ -90,9 +97,10 @@ export function StreamPlayerModal({
     // What we render: the user's pick if available, else the first available
     // source (3D View is virtual, so there's always a fallback). The pick is
     // kept and restored if its publisher comes back.
-    const activeSource = isSourceAvailable(selectedStreamSource)
+    const activeSource = isStreamSourceAvailable(selectedStreamSource, availableTopics)
         ? selectedStreamSource
-        : streamSources.find(isSourceAvailable) ?? selectedStreamSource;
+        : streamSources.find((s) => isStreamSourceAvailable(s, availableTopics)) ??
+          selectedStreamSource;
 
     const handleFullscreenToggle = () => {
         const container = containerRef.current;
@@ -109,16 +117,17 @@ export function StreamPlayerModal({
         }
     };
 
-    const selectOptions = useMemo(() =>
-        streamSources.map(source => {
-            const available = isSourceAvailable(source);
-            return {
-                value: source.id,
-                label: available ? source.name : `${source.name} (unavailable)`,
-                disabled: !available,
-            };
-        }),
-        [streamSources, availableTopics]
+    const selectOptions = useMemo(
+        () =>
+            streamSources.map((source) => {
+                const available = isStreamSourceAvailable(source, availableTopics);
+                return {
+                    value: source.id,
+                    label: available ? source.name : `${source.name} (unavailable)`,
+                    disabled: !available,
+                };
+            }),
+        [streamSources, availableTopics],
     );
 
     const is3DView = activeSource.virtual === true;

--- a/src/Components/StreamPlayerModal.tsx
+++ b/src/Components/StreamPlayerModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { Select, Button, Tooltip } from 'antd';
 import { FullscreenOutlined, FullscreenExitOutlined } from '@ant-design/icons';
 import { StreamPlayer } from "./StreamPlayer.tsx";
@@ -6,7 +6,8 @@ import { StreamMetrics } from "./StreamMetrics.tsx";
 import { MovableModal } from './MovableModal.tsx';
 import Robot3DViewer from '../Pages/Robot3DViewer.tsx';
 import { useAvailableTopics } from '../hooks/useAvailableTopics.ts';
-import { STREAM_SOURCES, DEFAULT_STREAM_SOURCE } from '../Constants/rosConfig';
+import { useStreamSources } from '../hooks/useStreamSources.ts';
+import { DEFAULT_STREAM_SOURCE } from '../Constants/rosConfig';
 import type { StreamSource } from '../Constants/rosConfig';
 import {
     UI_WARNING,
@@ -24,9 +25,6 @@ const WARNING_BADGE_STYLE: React.CSSProperties = {
     border: `1px solid ${UI_WARNING}`,
     borderRadius: 4
 };
-
-/** Real (non-virtual) stream topics whose publishers we probe for availability. */
-const CAMERA_TOPICS = STREAM_SOURCES.filter(s => !s.virtual).map(s => s.topic);
 
 const SELECT_POPUP_STYLE = {
     popup: {
@@ -58,16 +56,31 @@ export function StreamPlayerModal({
     const [hasEmptyDataWarning, setHasEmptyDataWarning] = useState<boolean>(false);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
+    const streamSources = useStreamSources();
+    const cameraTopics = useMemo(
+        () => streamSources.filter((s) => !s.virtual).map((s) => s.topic),
+        [streamSources],
+    );
+
+    // Drop selection when active config changes and the prior camera is no longer listed.
+    useEffect(() => {
+        if (streamSources.some((s) => s.id === selectedStreamSource.id)) return;
+        const firstCamera = streamSources.find((s) => !s.virtual) ?? streamSources[0];
+        if (firstCamera) {
+            setSelectedStreamSource(firstCamera);
+            setHasEmptyDataWarning(false);
+        }
+    }, [streamSources, selectedStreamSource.id]);
 
     // Camera topics with a live publisher (null = unknown → assume available).
-    const availableTopics = useAvailableTopics(CAMERA_TOPICS, isVisible);
+    const availableTopics = useAvailableTopics(cameraTopics, isVisible);
 
     // Selectable if virtual, has a publisher, or availability is still unknown.
     const isSourceAvailable = (source: StreamSource): boolean =>
         source.virtual === true || availableTopics === null || availableTopics.has(source.topic);
 
     const handleStreamSourceChange = (value: string) => {
-        const source = STREAM_SOURCES.find(s => s.id === value);
+        const source = streamSources.find(s => s.id === value);
         if (source) {
             setSelectedStreamSource(source);
             setHasEmptyDataWarning(false);
@@ -79,7 +92,7 @@ export function StreamPlayerModal({
     // kept and restored if its publisher comes back.
     const activeSource = isSourceAvailable(selectedStreamSource)
         ? selectedStreamSource
-        : STREAM_SOURCES.find(isSourceAvailable) ?? selectedStreamSource;
+        : streamSources.find(isSourceAvailable) ?? selectedStreamSource;
 
     const handleFullscreenToggle = () => {
         const container = containerRef.current;
@@ -97,7 +110,7 @@ export function StreamPlayerModal({
     };
 
     const selectOptions = useMemo(() =>
-        STREAM_SOURCES.map(source => {
+        streamSources.map(source => {
             const available = isSourceAvailable(source);
             return {
                 value: source.id,
@@ -105,7 +118,7 @@ export function StreamPlayerModal({
                 disabled: !available,
             };
         }),
-        [availableTopics]
+        [streamSources, availableTopics]
     );
 
     const is3DView = activeSource.virtual === true;

--- a/src/Constants/rosConfig.ts
+++ b/src/Constants/rosConfig.ts
@@ -52,38 +52,13 @@ export interface StreamSource {
     virtual?: boolean;
 }
 
-export const STREAM_SOURCES: StreamSource[] = [
-    {
-        id: 'ext-camera',
-        name: 'External USB Webcam',
-        topic: '/ext_camera/jpg',
-        messageType: 'sensor_msgs/msg/CompressedImage'
-    },
-    {
-        id: 'gazebo',
-        name: 'Gazebo Webcam',
-        topic: '/camera/gazebo/compressed',
-        messageType: 'sensor_msgs/msg/CompressedImage'
-    },
-    {
-        id: 'realsense-rgb',
-        name: 'Realsense RGB',
-        topic: '/realsense/realsense2_camera/color/image_raw/compressed',
-        messageType: 'sensor_msgs/msg/CompressedImage'
-    },
-    {
-        id: 'realsense-aligned-depth',
-        name: 'Realsense Aligned Depth',
-        topic: '/realsense/realsense2_camera/aligned_depth_to_color/image_raw/compressed',
-        messageType: 'sensor_msgs/msg/CompressedImage'
-    },
-    {
-        id: '3d-view',
-        name: '3D View',
-        topic: '',
-        messageType: '',
-        virtual: true,
-    },
-];
+export const STREAM_SOURCE_3D_VIEW: StreamSource = {
+    id: '3d-view',
+    name: '3D View',
+    topic: '',
+    messageType: '',
+    virtual: true,
+};
 
-export const DEFAULT_STREAM_SOURCE = STREAM_SOURCES[0];
+/** Initial placeholder until a camera from the active config is selected. */
+export const DEFAULT_STREAM_SOURCE = STREAM_SOURCE_3D_VIEW;

--- a/src/Utils/streamSourcesFromHardwareYaml.ts
+++ b/src/Utils/streamSourcesFromHardwareYaml.ts
@@ -1,0 +1,55 @@
+import type { StreamSource } from '../Constants/rosConfig';
+
+const CAMERA_META_KEYS = new Set([
+    'name',
+    'topic',
+    'message_type',
+    'external',
+    'link',
+    'sim_gz_topic',
+]);
+
+const DEFAULT_CAMERA_MESSAGE_TYPE = 'sensor_msgs/msg/CompressedImage';
+
+function cameraEntryId(entry: Record<string, unknown>): string {
+    const explicit = entry.id;
+    if (typeof explicit === 'string' && explicit.trim()) {
+        return explicit.trim();
+    }
+    for (const [key, value] of Object.entries(entry)) {
+        if (CAMERA_META_KEYS.has(key)) continue;
+        if (value === null || value === undefined) {
+            return key;
+        }
+    }
+    const topic = typeof entry.topic === 'string' ? entry.topic : '';
+    return topic.replace(/^\//, '').replace(/[^\w]+/g, '-') || 'camera';
+}
+
+/** Camera stream entries from hardware YAML ``cameras`` (matches active.yaml / lucy_config_generator). */
+export function streamSourcesFromHardwareYaml(doc: Record<string, unknown>): StreamSource[] {
+    const cameras = doc.cameras;
+    if (!Array.isArray(cameras)) return [];
+
+    const out: StreamSource[] = [];
+    for (const row of cameras) {
+        if (!row || typeof row !== 'object' || Array.isArray(row)) continue;
+        const entry = row as Record<string, unknown>;
+        const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+        const topic = typeof entry.topic === 'string' ? entry.topic.trim() : '';
+        if (!name || !topic) continue;
+
+        const messageType =
+            typeof entry.message_type === 'string' && entry.message_type.trim()
+                ? entry.message_type.trim()
+                : DEFAULT_CAMERA_MESSAGE_TYPE;
+
+        out.push({
+            id: cameraEntryId(entry),
+            name,
+            topic,
+            messageType,
+        });
+    }
+    return out;
+}

--- a/src/Utils/streamSourcesFromHardwareYaml.ts
+++ b/src/Utils/streamSourcesFromHardwareYaml.ts
@@ -3,6 +3,7 @@ import type { StreamSource } from '../Constants/rosConfig';
 const CAMERA_META_KEYS = new Set([
     'name',
     'topic',
+    'compressed_topic',
     'message_type',
     'external',
     'link',
@@ -22,7 +23,7 @@ function cameraEntryId(entry: Record<string, unknown>): string {
             return key;
         }
     }
-    const topic = typeof entry.topic === 'string' ? entry.topic : '';
+    const topic = typeof entry.compressed_topic === 'string' ? entry.compressed_topic : '';
     return topic.replace(/^\//, '').replace(/[^\w]+/g, '-') || 'camera';
 }
 
@@ -36,7 +37,7 @@ export function streamSourcesFromHardwareYaml(doc: Record<string, unknown>): Str
         if (!row || typeof row !== 'object' || Array.isArray(row)) continue;
         const entry = row as Record<string, unknown>;
         const name = typeof entry.name === 'string' ? entry.name.trim() : '';
-        const topic = typeof entry.topic === 'string' ? entry.topic.trim() : '';
+        const topic = typeof entry.compressed_topic === 'string' ? entry.compressed_topic.trim() : '';
         if (!name || !topic) continue;
 
         const messageType =

--- a/src/Utils/streamSourcesFromHardwareYaml.ts
+++ b/src/Utils/streamSourcesFromHardwareYaml.ts
@@ -36,7 +36,7 @@ export function streamSourcesFromHardwareYaml(doc: Record<string, unknown>): Str
         if (!row || typeof row !== 'object' || Array.isArray(row)) continue;
         const entry = row as Record<string, unknown>;
         const name = typeof entry.name === 'string' ? entry.name.trim() : '';
-        const topic = typeof entry.topic === 'string' ? entry.topic.trim() : '';
+        const topic = typeof entry.topic === 'string' ? entry.topic.trim() + '/compressed' : '';
         if (!name || !topic) continue;
 
         const messageType =

--- a/src/Utils/streamSourcesFromHardwareYaml.ts
+++ b/src/Utils/streamSourcesFromHardwareYaml.ts
@@ -36,7 +36,7 @@ export function streamSourcesFromHardwareYaml(doc: Record<string, unknown>): Str
         if (!row || typeof row !== 'object' || Array.isArray(row)) continue;
         const entry = row as Record<string, unknown>;
         const name = typeof entry.name === 'string' ? entry.name.trim() : '';
-        const topic = typeof entry.topic === 'string' ? entry.topic.trim() + '/compressed' : '';
+        const topic = typeof entry.topic === 'string' ? entry.topic.trim() : '';
         if (!name || !topic) continue;
 
         const messageType =

--- a/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
+++ b/src/features/hardwareConfiguration/components/ActivateConfigureWorkflowModal.tsx
@@ -385,10 +385,9 @@ function GazeboRestartDiffBody({ diff }: { diff: HardwareConfigDiff | null }) {
             <div style={{ fontSize: 12 }}>
                 <Text strong>In Lucy TUI:</Text>
                 <ol style={{ margin: '6px 0 0', paddingLeft: 18 }}>
-                    <li>Untick "with Simulator"</li>
-                    <li>Press enter to stop the simulator</li>
-                    <li>Tick back "with Simulator"</li>
-                    <li>Press enter to restart the stack with the simulator</li>
+                    <li>Press "x" to exit</li>
+                    <li>Press "y" to confirm</li>
+                    <li>Restart the stack with the simulator</li>
                 </ol>
             </div>
             {diff ? (

--- a/src/hooks/useStreamSources.ts
+++ b/src/hooks/useStreamSources.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { STREAM_SOURCE_3D_VIEW, type StreamSource } from '../Constants/rosConfig';
+import { useActiveHardwareRos } from '../contexts/ActiveHardwareRosContext';
+import { streamSourcesFromHardwareYaml } from '../Utils/streamSourcesFromHardwareYaml';
+
+/** Stream picker entries: cameras from active hardware config + virtual 3D view. */
+export function useStreamSources(): StreamSource[] {
+    const { activeHardwareDoc, activeHardwareFetchEpoch } = useActiveHardwareRos();
+
+    return useMemo(() => {
+        const cameras = activeHardwareDoc
+            ? streamSourcesFromHardwareYaml(activeHardwareDoc)
+            : [];
+        return [...cameras, STREAM_SOURCE_3D_VIEW];
+        // activeHardwareFetchEpoch: rebuild when pipeline activates a new preset.
+    }, [activeHardwareDoc, activeHardwareFetchEpoch]);
+}


### PR DESCRIPTION
## Summary
- Camera stream picker now lists cameras from the active hardware config instead of a hardcoded list.
- Only cameras with a live publisher are selectable; others show as `(unavailable)`.
- Picker refreshes when a new preset is activated.
- Updated Gazebo restart steps in the Activate & Configure modal to match the current TUI.